### PR TITLE
Scan all files for @NpmPackage

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -13,7 +13,7 @@ const replace = require('replace-in-file');
 
 
 async function computeModules(){
-  const cmd = 'grep -r @NpmPackage ./vaadin*parent/vaadin*flow/src/*/java';
+  const cmd = 'grep -r @NpmPackage ./vaadin*parent/*/src/*/java';
   const output = await run(cmd);
   const lines = output.split('\n').filter(Boolean);
   return lines.map(line => {


### PR DESCRIPTION
because we have some @NpmPackage annotation inside the IT module (for example: [here](https://github.com/vaadin/vaadin-flow-components/blob/3651186a3ad91f480373729f15f709a989c3d968/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/src/main/java/com/vaadin/flow/component/accordion/examples/AccordionInTemplate.java)), so the script should go through files there for the annotation update