### PR TITLE
Remove the vaadin-charts-flow/demo folder

### DIFF
--- a/scripts/updateFromMaster.sh
+++ b/scripts/updateFromMaster.sh
@@ -57,6 +57,8 @@ consolidateCharts() {
   perl -pi -e "s,>$prj-examples<,>$prj-demo<,g" $mod/*/pom.xml
   renameModule $mod integration-test $prj-integration-tests
   renameModule $mod testbench $tb
+  # remove the demo folder from vaadin-charts-flow
+  rm -rf $mod/demo
 }
 
 consolidatePoms() {


### PR DESCRIPTION
Charts used to have `examples` and `demo` folders but `demo` was removed from v15+