### PR TITLE
fix: remove the debouncing of ensureSubCacheForScaledIndex

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
@@ -70,7 +70,14 @@ public class TreeGridExpandAllPage extends Div {
         treeGrid.addCollapseListener(e -> treeGrid.recalculateColumnWidths());
         treeGrid.addExpandListener(e -> treeGrid.recalculateColumnWidths());
 
-        add(treeGrid);
+        NativeButton expandTree = new NativeButton("Expand and scroll",
+                event -> treeGrid.expand("Granddad 0",
+                        "Dad is very long and large 0/0",
+                        "Dad is very long and large 0/1",
+                        "Dad is very long and large 0/2"));
+        expandTree.setId("expand-tree");
+
+        add(treeGrid, expandTree);
     }
     private void initializeDataProvider() {
         TreeData<String> data = new TreeData<>();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllIT.java
@@ -15,19 +15,17 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
-import java.util.List;
-
-import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridColumnElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-
-import com.vaadin.flow.component.grid.testbench.GridColumnElement;
-import com.vaadin.flow.component.grid.testbench.GridTRElement;
-import com.vaadin.flow.testutil.TestPath;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebElement;
+
+import java.util.Arrays;
+import java.util.List;
 
 @TestPath("vaadin-grid/treegrid-expand-all")
 public class TreeGridExpandAllIT extends AbstractTreeGridIT {
@@ -65,6 +63,38 @@ public class TreeGridExpandAllIT extends AbstractTreeGridIT {
         Assert.assertEquals(widthBeforeExpend, widthAfterCollapse);
     }
 
+    @Test
+    public void loadingIsFalseAfterScrolling() {
+        open();
+        TreeGridElement grid = $(TreeGridElement.class).get(1);
+        findElement(By.id("expand-tree")).click();
+
+        List<Integer> scrollValues = Arrays.asList(44958, 5600, 10600, 20650,
+                25650, 30150, 35700, 38700, 33200, 30150);
+
+        // If updating of the scrollTop for table is happening with
+        // the round trip, issue doesn't occur.
+        executeScript("const grid = arguments[0];" +
+                "grid.setAttribute('component-test-scrolling', '');" +
+                "const scrollValues = arguments[1];" +
+                "let iterator = 0;" +
+                "const updateScroll = function() {" +
+                "  if (iterator == 9) {" +
+                "    iterator = 0;" +
+                "  }" +
+                "  grid.$.table.scrollTop = scrollValues[iterator];" +
+                "  iterator ++;" +
+                "};" +
+                "const interval = setInterval(updateScroll, 1);" +
+                "setTimeout(e => {" +
+                "  clearInterval(interval);" +
+                "  grid.removeAttribute('component-test-scrolling');" +
+                "}, 5000);", grid, scrollValues);
+
+        waitUntil(e -> !grid.hasAttribute("component-test-scrolling") &&
+                !grid.getPropertyBoolean("loading"));
+    }
+
     private void runAddNewItemAfterCollapseAndExpand()
             throws InterruptedException {
         open();
@@ -73,8 +103,8 @@ public class TreeGridExpandAllIT extends AbstractTreeGridIT {
 
         waitUntil(driver -> getTreeGrid().getRowCount() == 5);
 
-        $("button").id("collapse").click();
-        $("button").id("expand").click();
+        findElement(By.id("collapse")).click();
+        findElement(By.id("expand")).click();
         waitUntil(driver -> getTreeGrid().getRowCount() == 5);
 
         findElement(By.id("add-new")).click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -30,10 +30,10 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
             return;
           }
 
-        if (!this.itemCaches[scaledIndex]) {
-          this.doEnsureSubCacheForScaledIndex(scaledIndex);
-        }
-      })
+          if (!this.itemCaches[scaledIndex]) {
+            this.doEnsureSubCacheForScaledIndex(scaledIndex);
+          }
+        });
 
         ItemCache.prototype.doEnsureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
           if (!this.itemCaches[scaledIndex]) {

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -4,14 +4,14 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
- * the License. 
+ * the License.
  */
 package com.vaadin.flow.component.grid.testbench;
 
@@ -268,7 +268,7 @@ public class TreeGridElement extends GridElement {
      * Returns a number of expanded rows in the grid element. Notice that
      * returned number does not mean that grid has yet finished rendering all
      * visible expanded rows.
-     * 
+     *
      * @return the number of expanded rows
      */
     public long getNumberOfExpandedRows() {
@@ -279,7 +279,7 @@ public class TreeGridElement extends GridElement {
 
     /**
      * Returns {@code true} if details are open or the given row index.
-     * 
+     *
      * @param rowIndex
      *            the 0-based row index
      * @return {@code true} if details are shown in the target row
@@ -294,7 +294,7 @@ public class TreeGridElement extends GridElement {
 
     /**
      * Returns true if given index has tr element for the row
-     * 
+     *
      * @param row
      *            the row index
      * @return <code>true</code> if there is tr element for the row,
@@ -310,13 +310,13 @@ public class TreeGridElement extends GridElement {
 
     /**
      * Returns true if grid is loading expanded rows.
-     * 
+     *
      * @return <code>true</code> if grid is loading expanded rows,
      *         <code>false</code> otherwise
      */
     public boolean isLoadingExpandedRows() {
         return (Boolean) executeScript(
-                "return arguments[0].$connector && (arguments[0].$connector.hasEnsureSubCacheQueue() || arguments[0].$connector.hasParentRequestQueue())",
+                "return arguments[0].$connector && arguments[0].$connector.hasParentRequestQueue()",
                 this);
     }
 


### PR DESCRIPTION
Web-component: grid

Fixes: https://github.com/vaadin/vaadin-grid/issues/1809

Details: Flow Grid's connector overrides the ensureSubCacheForScaledIndex function, and adds a debouncer for the logic, the data request gets made asynchronously when expanding the Grids item. If the request for recalculateColumnWithds is done on expand listener, the width calculation might occasionally happen before the node gets expanded on the client-side, thus resulting into columns with undesired widths.