### PR TITLE
feat: Take IdentifierProvider into use for equality determination in list-box

### DIFF
--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
@@ -64,8 +64,10 @@ public class ListBoxDataViewPage extends Div {
     static final String LIST_DATA_VIEW_NEXT_BUTTON = "list-data-view-next-button";
     static final String LIST_DATA_VIEW_PREV_BUTTON = "list-data-view-prev-button";
     static final String LIST_DATA_VIEW_SORT_BUTTON = "list-data-view-sort-button";
-    static final String LIST_BOX_SELECTION_UPDATE_BUTTON = "list-box-selection-update-button";
+    static final String LIST_BOX_SELECTION_BY_ID_UPDATE_BUTTON = "list-box-selection-by-id-update-button";
+    static final String LIST_BOX_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON = "list-box-selection-by-id-and-name-update-button";
     static final String MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON = "multi-select-list-box-selection-update-button";
+    static final String MULTI_SELECT_LIST_BOX_SELECTION_BY_ID_AND_NAME_BUTTON = "multi-select-list-box-selection-by-id-and-name-button";
 
     static final String CURRENT_ITEM_SPAN = "current-item-span";
     static final String HAS_NEXT_ITEM_SPAN = "has-next-item-span";
@@ -290,17 +292,19 @@ public class ListBoxDataViewPage extends Div {
                 .reduce((a, b) -> a + ", " + b)
                 .ifPresent(selectedIdsSpan::setText);
 
-        Button updateButton = new Button("Update", click -> {
+        Button updateAndSelectByIdButton =
+                new Button("Update & Select by Id", click -> {
             // Make the names of unselected items similar to the name of selected
             // one to mess with the <equals> implementation in CustomItem:
             second.setName("First");
             listDataView.refreshItem(second);
 
             fourth.setName("Third");
-            listDataView.refreshItem(third);
+            listDataView.refreshItem(fourth);
 
             // Select the items not only with the reference of existing items,
-            // but also the Id:
+            // but also the Id to verify <equals> is not in use and the
+            // selection is happening only based on identifier:
             Set<CustomItem> newSelected = new HashSet<>(Arrays.asList(
                     second, new CustomItem(4L)));
             multiSelectListBox.setValue(newSelected);
@@ -312,9 +316,30 @@ public class ListBoxDataViewPage extends Div {
                     .reduce((a, b) -> a + ", " + b)
                     .ifPresent(selectedIdsSpan::setText);
         });
-        updateButton.setId(MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON);
+        updateAndSelectByIdButton
+                .setId(MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON);
 
-        add(multiSelectListBox, selectedIdsSpan, updateButton);
+        Button selectByIdAndNameButton =
+                new Button("Select by Id and Name", click -> {
+            // Select the items not only with the reference of existing items,
+            // but also the Id and a challenging name to verify <equals> is not
+            // in use and the selection is happening only based on identifier:
+            Set<CustomItem> newSelected = new HashSet<>(Arrays.asList(
+                    first, new CustomItem(3L, "Third")));
+            multiSelectListBox.setValue(newSelected);
+
+            multiSelectListBox.getSelectedItems()
+                    .stream()
+                    .map(item -> String.valueOf(item.getId()))
+                    .sorted()
+                    .reduce((a, b) -> a + ", " + b)
+                    .ifPresent(selectedIdsSpan::setText);
+        });
+        selectByIdAndNameButton
+                .setId(MULTI_SELECT_LIST_BOX_SELECTION_BY_ID_AND_NAME_BUTTON);
+
+        add(multiSelectListBox, selectedIdsSpan, updateAndSelectByIdButton,
+                selectByIdAndNameButton);
     }
 
     private void createIdentifierProviderForListBox() {
@@ -336,9 +361,11 @@ public class ListBoxDataViewPage extends Div {
         selectedIdsSpan.setId(LIST_BOX_SELECTED_IDS_SPAN);
         selectedIdsSpan.setText(String.valueOf(listBox.getValue().getId()));
 
-        Button updateButton = new Button("Update", click -> {
-            // Make the names of unselected items similar to the name of selected
-            // one to mess with the <equals> implementation in CustomItem:
+        Button updateAndSelectByIdOnlyButton =
+                new Button("Update & Select by Id", click -> {
+            // Make the names of unselected items similar to the name of
+            // selected one to mess with the <equals> implementation in
+            // CustomItem:
             first.setName("Second");
             listDataView.refreshItem(first);
 
@@ -351,9 +378,23 @@ public class ListBoxDataViewPage extends Div {
 
             selectedIdsSpan.setText(String.valueOf(listBox.getValue().getId()));
         });
-        updateButton.setId(LIST_BOX_SELECTION_UPDATE_BUTTON);
+        updateAndSelectByIdOnlyButton
+                .setId(LIST_BOX_SELECTION_BY_ID_UPDATE_BUTTON);
 
-        add(listBox, selectedIdsSpan, updateButton);
+        Button selectByIdAndNameButton =
+                new Button("Select by Id and Name", click -> {
+                    // Select the item with the Id and a challenging wrong name
+                    // to verify <equals> method is not in use:
+                    listBox.setValue(new CustomItem(3L, "Second"));
+
+                    selectedIdsSpan.setText(
+                            String.valueOf(listBox.getValue().getId()));
+                });
+        selectByIdAndNameButton
+                .setId(LIST_BOX_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON);
+
+        add(listBox, selectedIdsSpan, updateAndSelectByIdOnlyButton,
+                selectByIdAndNameButton);
     }
 
     private static class GenericDataProvider

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
@@ -18,15 +18,19 @@ package com.vaadin.flow.component.listbox.test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxDataView;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
@@ -60,10 +64,15 @@ public class ListBoxDataViewPage extends Div {
     static final String LIST_DATA_VIEW_NEXT_BUTTON = "list-data-view-next-button";
     static final String LIST_DATA_VIEW_PREV_BUTTON = "list-data-view-prev-button";
     static final String LIST_DATA_VIEW_SORT_BUTTON = "list-data-view-sort-button";
+    static final String LIST_BOX_SELECTION_UPDATE_BUTTON = "list-box-selection-update-button";
+    static final String MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON = "multi-select-list-box-selection-update-button";
 
     static final String CURRENT_ITEM_SPAN = "current-item-span";
     static final String HAS_NEXT_ITEM_SPAN = "has-next-item-span";
     static final String HAS_PREV_ITEM_SPAN = "has-prev-item-span";
+    static final String LIST_BOX_SELECTED_IDS_SPAN = "list-box-selected-ids-span";
+    static final String MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN = "multi-select-list-box-selected-ids-span";
+
 
     public ListBoxDataViewPage() {
         createGenericDataView();
@@ -73,6 +82,8 @@ public class ListBoxDataViewPage extends Div {
         createFilterItemsByDataView();
         createNextPreviousItemDataView();
         createSetSortComparatorDataView();
+        createIdentifierProviderForMultiSelectListBox();
+        createIdentifierProviderForListBox();
     }
 
     private void createGenericDataView() {
@@ -251,6 +262,100 @@ public class ListBoxDataViewPage extends Div {
         add(listBoxForSortDataView, dataViewSortButton);
     }
 
+    private void createIdentifierProviderForMultiSelectListBox() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        CustomItem fourth = new CustomItem(4L, "Fourth");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third, fourth));
+
+        MultiSelectListBox<CustomItem> multiSelectListBox =
+                new MultiSelectListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = multiSelectListBox
+                .setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        Set<CustomItem> selected = new HashSet<>(Arrays.asList(
+                new CustomItem(1L), third));
+        multiSelectListBox.setValue(selected);
+
+        Span selectedIdsSpan = new Span();
+        selectedIdsSpan.setId(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN);
+        multiSelectListBox.getSelectedItems().stream()
+                .map(item -> String.valueOf(item.getId()))
+                .sorted()
+                .reduce((a, b) -> a + ", " + b)
+                .ifPresent(selectedIdsSpan::setText);
+
+        Button updateButton = new Button("Update", click -> {
+            // Make the names of unselected items similar to the name of selected
+            // one to mess with the <equals> implementation in CustomItem:
+            second.setName("First");
+            listDataView.refreshItem(second);
+
+            fourth.setName("Third");
+            listDataView.refreshItem(third);
+
+            // Select the items not only with the reference of existing items,
+            // but also the Id:
+            Set<CustomItem> newSelected = new HashSet<>(Arrays.asList(
+                    second, new CustomItem(4L)));
+            multiSelectListBox.setValue(newSelected);
+
+            multiSelectListBox.getSelectedItems()
+                    .stream()
+                    .map(item -> String.valueOf(item.getId()))
+                    .sorted()
+                    .reduce((a, b) -> a + ", " + b)
+                    .ifPresent(selectedIdsSpan::setText);
+        });
+        updateButton.setId(MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON);
+
+        add(multiSelectListBox, selectedIdsSpan, updateButton);
+    }
+
+    private void createIdentifierProviderForListBox() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> listBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = listBox.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        listBox.setValue(new CustomItem(3L));
+
+        Span selectedIdsSpan = new Span();
+        selectedIdsSpan.setId(LIST_BOX_SELECTED_IDS_SPAN);
+        selectedIdsSpan.setText(String.valueOf(listBox.getValue().getId()));
+
+        Button updateButton = new Button("Update", click -> {
+            // Make the names of unselected items similar to the name of selected
+            // one to mess with the <equals> implementation in CustomItem:
+            first.setName("Second");
+            listDataView.refreshItem(first);
+
+            third.setName("Second");
+            listDataView.refreshItem(third);
+
+            // Select the item not with the reference of existing item,
+            // and instead with just the Id:
+            listBox.setValue(new CustomItem(2L));
+
+            selectedIdsSpan.setText(String.valueOf(listBox.getValue().getId()));
+        });
+        updateButton.setId(LIST_BOX_SELECTION_UPDATE_BUTTON);
+
+        add(listBox, selectedIdsSpan, updateButton);
+    }
+
     private static class GenericDataProvider
             extends AbstractDataProvider<Item, Void> {
         private final transient List<Item> items;
@@ -322,6 +427,45 @@ public class ListBoxDataViewPage extends Div {
 
         public String toString() {
             return String.valueOf(this.value);
+        }
+    }
+
+    private static class CustomItem {
+        private Long id;
+        private String name;
+
+        public CustomItem(Long id) {
+            this(id, null);
+        }
+
+        public CustomItem(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof CustomItem)) return false;
+            CustomItem that = (CustomItem) o;
+            return Objects.equals(getName(), that.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName());
         }
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxViewDemoPage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxViewDemoPage.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
@@ -93,7 +94,7 @@ public class ListBoxViewDemoPage extends DemoView {
         // begin-source-example
         // source-example-heading: Using item renderer and disabling items
         ListBox<Item> listBox = new ListBox<>();
-        listBox.setItems(getItems());
+        ListBoxListDataView<Item> listDataView = listBox.setItems(getItems());
 
         listBox.setRenderer(new ComponentRenderer<>(item -> {
             Label name = new Label("Item: " + item.getName());
@@ -101,7 +102,7 @@ public class ListBoxViewDemoPage extends DemoView {
 
             NativeButton button = new NativeButton("Buy", event -> {
                 item.setStock(item.getStock() - 1);
-                listBox.getDataProvider().refreshItem(item);
+                listDataView.refreshItem(item);
             });
 
             Div labels = new Div(name, stock);

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
@@ -37,6 +37,8 @@ import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BO
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_FOR_LIST_DATA_VIEW;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_FOR_SORT_DATA_VIEW;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTED_IDS_SPAN;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTION_UPDATE_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_ADD_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_ADD_FILTER_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_NEXT_BUTTON;
@@ -46,6 +48,8 @@ import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DA
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SET_FILTER_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SORT_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN;
 
 @TestPath("vaadin-list-box/list-box-data-view")
 public class ListBoxDataViewIT extends AbstractComponentIT {
@@ -65,18 +69,18 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
 
         findElement(By.id(DATA_VIEW_UPDATE_BUTTON)).click();
 
-        WebElement group = findElement(By.id(LIST_BOX_FOR_DATA_VIEW));
-        List<WebElement> buttons = group
+        WebElement listBox = findElement(By.id(LIST_BOX_FOR_DATA_VIEW));
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 2, buttons.size());
+        Assert.assertEquals("ListBox should have items", 2, items.size());
 
         Assert.assertEquals("First RadioButton should be updated to", CHANGED_1,
-                buttons.get(0).getText());
+                items.get(0).getText());
 
         Assert.assertEquals(
                 "Second RadioButton should still holds the old value", SECOND,
-                buttons.get(1).getText());
+                items.get(1).getText());
     }
 
     @Test
@@ -84,100 +88,100 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
 
         findElement(By.id(LIST_DATA_VIEW_UPDATE_BUTTON)).click();
 
-        WebElement group = findElement(By.id(LIST_BOX_FOR_LIST_DATA_VIEW));
-        List<WebElement> buttons = group
+        WebElement listBox = findElement(By.id(LIST_BOX_FOR_LIST_DATA_VIEW));
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 2, buttons.size());
+        Assert.assertEquals("ListBox should have items", 2, items.size());
 
         Assert.assertEquals("First RadioButton should be updated to", CHANGED_1,
-                buttons.get(0).getText());
+                items.get(0).getText());
 
         Assert.assertEquals(
                 "Second RadioButton should still holds the old value", SECOND,
-                buttons.get(1).getText());
+                items.get(1).getText());
     }
 
     @Test
     public void testListDataView_addItem_shouldAddOneAndOnlyOneItem() {
 
-        WebElement group = findElement(By.id(LIST_BOX_FOR_ADD_TO_DATA_VIEW));
-        List<WebElement> buttons = group
+        WebElement listBox = findElement(By.id(LIST_BOX_FOR_ADD_TO_DATA_VIEW));
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 1, buttons.size());
+        Assert.assertEquals("ListBox should have items", 1, items.size());
 
         findElement(By.id(LIST_DATA_VIEW_ADD_BUTTON)).click();
 
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_ADD_TO_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_ADD_TO_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 2, buttons.size());
+        Assert.assertEquals("ListBox should have items", 2, items.size());
 
         Assert.assertEquals("First RadioButton should have the text", FIRST,
-                buttons.get(0).getText());
+                items.get(0).getText());
 
         Assert.assertEquals("Second RadioButton should have the text", SECOND,
-                buttons.get(1).getText());
+                items.get(1).getText());
     }
 
     @Test
     public void testListDataView_removeItem_shouldRemoveOneAndOnlyOneItem() {
 
-        WebElement group = findElement(
+        WebElement listBox = findElement(
                 By.id(LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW));
-        List<WebElement> buttons = group
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 2, buttons.size());
+        Assert.assertEquals("ListBox should have items", 2, items.size());
 
         findElement(By.id(LIST_DATA_VIEW_REMOVE_BUTTON)).click();
 
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 1, buttons.size());
+        Assert.assertEquals("ListBox should have items", 1, items.size());
 
         Assert.assertEquals("First RadioButton should have the text", FIRST,
-                buttons.get(0).getText());
+                items.get(0).getText());
     }
 
     @Test
     public void testListDataView_addAndRemoveFilters_shouldProduceCorrectNumberOfRadioButtons() {
 
-        WebElement group = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
-        List<WebElement> buttons = group
+        WebElement listBox = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 10, buttons.size());
+        Assert.assertEquals("ListBox should have items", 10, items.size());
 
         findElement(By.id(LIST_DATA_VIEW_SET_FILTER_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 5, buttons.size());
+        Assert.assertEquals("ListBox should have items", 5, items.size());
 
         findElement(By.id(LIST_DATA_VIEW_ADD_FILTER_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 4, buttons.size());
+        Assert.assertEquals("ListBox should have items", 4, items.size());
 
         findElement(By.id(LIST_DATA_VIEW_REMOVE_FILTER_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_FILTER_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("ListBox should have items", 10, buttons.size());
+        Assert.assertEquals("ListBox should have items", 10, items.size());
     }
 
     @Test
@@ -223,28 +227,58 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
     @Test
     public void testListDataView_setSortComparator_shouldSortTheItems() {
 
-        WebElement group = findElement(By.id(LIST_BOX_FOR_SORT_DATA_VIEW));
-        List<WebElement> buttons = group
+        WebElement listBox = findElement(By.id(LIST_BOX_FOR_SORT_DATA_VIEW));
+        List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
         Assert.assertEquals("first rendered radio button's text should be",
-                "third", buttons.get(0).getText());
+                "third", items.get(0).getText());
         Assert.assertEquals("second rendered radio button's text should be",
-                "first", buttons.get(1).getText());
+                "first", items.get(1).getText());
         Assert.assertEquals("third rendered radio button's text should be",
-                "second", buttons.get(2).getText());
+                "second", items.get(2).getText());
 
         findElement(By.id(LIST_DATA_VIEW_SORT_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_ITEM));
 
-        group = findElement(By.id(LIST_BOX_FOR_SORT_DATA_VIEW));
-        buttons = group.findElements(By.tagName(VAADIN_ITEM));
+        listBox = findElement(By.id(LIST_BOX_FOR_SORT_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
         Assert.assertEquals("first rendered radio button's text should be",
-                "first", buttons.get(0).getText());
+                "first", items.get(0).getText());
         Assert.assertEquals("second rendered radio button's text should be",
-                "second", buttons.get(1).getText());
+                "second", items.get(1).getText());
         Assert.assertEquals("third rendered radio button's text should be",
-                "third", buttons.get(2).getText());
+                "third", items.get(2).getText());
+    }
+
+    @Test
+    public void setIdentifierProvider_forMultiSelectListBox_shouldSelectCorrectItems_dueToIdentifier() {
+        WebElement selectedIdsSpan = findElement(
+                By.id(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item ids should be", "1, 3",
+                selectedIdsSpan.getText());
+
+        findElement(By.id(MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON)).click();
+
+        selectedIdsSpan = findElement(
+                By.id(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item ids should be", "2, 4",
+                selectedIdsSpan.getText());
+    }
+
+    @Test
+    public void setIdentifierProvider_forListBox_shouldSelectCorrectItem_dueToIdentifier() {
+        WebElement selectedIdsSpan = findElement(
+                By.id(LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item id should be", "3",
+                selectedIdsSpan.getText());
+
+        findElement(By.id(LIST_BOX_SELECTION_UPDATE_BUTTON)).click();
+
+        selectedIdsSpan = findElement(
+                By.id(LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item ids should be", "2",
+                selectedIdsSpan.getText());
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
@@ -38,7 +38,8 @@ import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BO
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_FOR_SORT_DATA_VIEW;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTED_IDS_SPAN;
-import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTION_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_BOX_SELECTION_BY_ID_UPDATE_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_ADD_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_ADD_FILTER_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_NEXT_BUTTON;
@@ -48,6 +49,7 @@ import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DA
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SET_FILTER_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SORT_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTION_BY_ID_AND_NAME_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN;
 
@@ -231,11 +233,11 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
         List<WebElement> items = listBox
                 .findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("first rendered radio button's text should be",
+        Assert.assertEquals("first rendered item's text should be",
                 "third", items.get(0).getText());
-        Assert.assertEquals("second rendered radio button's text should be",
+        Assert.assertEquals("second rendered item's text should be",
                 "first", items.get(1).getText());
-        Assert.assertEquals("third rendered radio button's text should be",
+        Assert.assertEquals("third rendered item's text should be",
                 "second", items.get(2).getText());
 
         findElement(By.id(LIST_DATA_VIEW_SORT_BUTTON)).click();
@@ -244,16 +246,16 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
         listBox = findElement(By.id(LIST_BOX_FOR_SORT_DATA_VIEW));
         items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
-        Assert.assertEquals("first rendered radio button's text should be",
+        Assert.assertEquals("first rendered item's text should be",
                 "first", items.get(0).getText());
-        Assert.assertEquals("second rendered radio button's text should be",
+        Assert.assertEquals("second rendered item's text should be",
                 "second", items.get(1).getText());
-        Assert.assertEquals("third rendered radio button's text should be",
+        Assert.assertEquals("third rendered item's text should be",
                 "third", items.get(2).getText());
     }
 
     @Test
-    public void setIdentifierProvider_forMultiSelectListBox_shouldSelectCorrectItems_dueToIdentifier() {
+    public void setIdentifierProviderForMultiSelectListBox_setItem_shouldSelectCorrectItemsBasedOnIdentifier() {
         WebElement selectedIdsSpan = findElement(
                 By.id(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN));
         Assert.assertEquals("Selected item ids should be", "1, 3",
@@ -265,20 +267,35 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
                 By.id(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN));
         Assert.assertEquals("Selected item ids should be", "2, 4",
                 selectedIdsSpan.getText());
+
+        findElement(By.id(MULTI_SELECT_LIST_BOX_SELECTION_BY_ID_AND_NAME_BUTTON)).click();
+
+        selectedIdsSpan = findElement(
+                By.id(MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item ids should be", "1, 3",
+                selectedIdsSpan.getText());
+
     }
 
     @Test
-    public void setIdentifierProvider_forListBox_shouldSelectCorrectItem_dueToIdentifier() {
+    public void setIdentifierProviderForListBox_setItem_shouldSelectCorrectItemBasedOnIdentifier() {
         WebElement selectedIdsSpan = findElement(
                 By.id(LIST_BOX_SELECTED_IDS_SPAN));
         Assert.assertEquals("Selected item id should be", "3",
                 selectedIdsSpan.getText());
 
-        findElement(By.id(LIST_BOX_SELECTION_UPDATE_BUTTON)).click();
+        findElement(By.id(LIST_BOX_SELECTION_BY_ID_UPDATE_BUTTON)).click();
 
         selectedIdsSpan = findElement(
                 By.id(LIST_BOX_SELECTED_IDS_SPAN));
         Assert.assertEquals("Selected item ids should be", "2",
+                selectedIdsSpan.getText());
+
+        findElement(By.id(LIST_BOX_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON)).click();
+
+        selectedIdsSpan = findElement(
+                By.id(LIST_BOX_SELECTED_IDS_SPAN));
+        Assert.assertEquals("Selected item ids should be", "3",
                 selectedIdsSpan.getText());
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.listbox;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.data.selection.SingleSelect;
@@ -65,6 +66,21 @@ public class ListBox<T> extends ListBoxBase<ListBox<T>, T, T>
                         "Could not find given value from the item set"));
     }
 
+    /**
+     * Compares to value instances to each other to determine whether they are
+     * equal. Equality is used to determine whether to update internal state and
+     * fire an event when {@link #setValue(Object)} or
+     * {@link #setModelValue(Object, boolean)} is called. Subclasses can
+     * override this method to define an alternative comparison method instead
+     * of {@link Objects#equals(Object)}.
+     *
+     * @param value1
+     *            the first instance
+     * @param value2
+     *            the second instance
+     * @return <code>true</code> if the instances are equal; otherwise
+     *         <code>false</code>
+     */
     @Override
     protected boolean valueEquals(T value1, T value2) {
         if (value1 == null && value2 == null)

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
@@ -67,7 +67,7 @@ public class ListBox<T> extends ListBoxBase<ListBox<T>, T, T>
     }
 
     /**
-     * Compares to value instances to each other to determine whether they are
+     * Compares two value instances to each other to determine whether they are
      * equal. Equality is used to determine whether to update internal state and
      * fire an event when {@link #setValue(Object)} or
      * {@link #setModelValue(Object, boolean)} is called. Subclasses can

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBox.java
@@ -64,4 +64,13 @@ public class ListBox<T> extends ListBoxBase<ListBox<T>, T, T>
                 .findFirst().orElseThrow(() -> new IllegalArgumentException(
                         "Could not find given value from the item set"));
     }
+
+    @Override
+    protected boolean valueEquals(T value1, T value2) {
+        if (value1 == null && value2 == null)
+            return true;
+        if (value1 == null || value2 == null)
+            return false;
+        return getItemId(value1).equals(getItemId(value2));
+    }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
@@ -134,12 +134,29 @@ public class MultiSelectListBox<T>
                         event.getOldValue(), event.isFromClient())));
     }
 
+    /**
+     * Compares to value instances to each other to determine whether they are
+     * equal. Equality is used to determine whether to update internal state and
+     * fire an event when {@link #setValue(Object)} or
+     * {@link #setModelValue(Object, boolean)} is called. Subclasses can
+     * override this method to define an alternative comparison method instead
+     * of {@link Objects#equals(Object)}.
+     *
+     * @param value1
+     *            the first set of instance
+     * @param value2
+     *            the second set of instance
+     * @return <code>true</code> if sets are equal in size and also the items;
+     *         otherwise <code>false</code>
+     */
     @Override
     protected boolean valueEquals(Set<T> value1, Set<T> value2) {
-        assert value1 != null && value2 != null;
-        if (value1.size() != value2.size()) {
+        if (value1 == null && value2 == null)
+            return true;
+        if (value1 == null || value2 == null)
             return false;
-        }
+        if (value1.size() != value2.size())
+            return false;
 
         Set<Object> ids1 = value1.stream().map(super::getItemId)
                 .collect(Collectors.toSet());

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
@@ -135,7 +135,7 @@ public class MultiSelectListBox<T>
     }
 
     /**
-     * Compares to value instances to each other to determine whether they are
+     * Compares two value instances to each other to determine whether they are
      * equal. Equality is used to determine whether to update internal state and
      * fire an event when {@link #setValue(Object)} or
      * {@link #setModelValue(Object, boolean)} is called. Subclasses can

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBox.java
@@ -133,4 +133,18 @@ public class MultiSelectListBox<T>
                 .selectionChange(new MultiSelectionEvent<>(this, this,
                         event.getOldValue(), event.isFromClient())));
     }
+
+    @Override
+    protected boolean valueEquals(Set<T> value1, Set<T> value2) {
+        assert value1 != null && value2 != null;
+        if (value1.size() != value2.size()) {
+            return false;
+        }
+
+        Set<Object> ids1 = value1.stream().map(super::getItemId)
+                .collect(Collectors.toSet());
+        Set<Object> ids2 = value2.stream().map(super::getItemId)
+                .collect(Collectors.toSet());
+        return ids1.equals(ids2);
+    }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/CustomItem.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/CustomItem.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.listbox.test;
+
+import java.util.Objects;
+
+public class CustomItem {
+    private Long id;
+    private String name;
+
+    public CustomItem(Long id) {
+        this(id, null);
+    }
+
+    public CustomItem(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomItem)) return false;
+        CustomItem that = (CustomItem) o;
+        return Objects.equals(getName(), that.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+}

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
@@ -17,6 +19,9 @@ public class ListBoxUnitTest {
     private static final String ITEM2 = "2";
 
     private ListBox<String> listBox;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void init() {
@@ -54,7 +59,7 @@ public class ListBoxUnitTest {
     }
 
     @Test
-    public void setIdentifierProvider_shouldSelectCorrectItem_dueToIdentifier() {
+    public void setIdentifierProvider_setItemWithIdentifierOnly_shouldSelectCorrectItem() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -85,6 +90,77 @@ public class ListBoxUnitTest {
 
         Assert.assertNotNull(listBox.getValue());
         Assert.assertEquals(Long.valueOf(2L), listBox.getValue().getId());
+    }
+
+    @Test
+    public void setIdentifierProvider_setItemWithIdAndWrongName_shouldSelectCorrectItemBasedOnIdNotEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> listBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = listBox.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        listBox.setValue(new CustomItem(1L));
+
+        Assert.assertNotNull(listBox.getValue());
+        Assert.assertEquals(listBox.getValue().getName(), "First");
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item with an Id and the name that can be wrongly equals to
+        // another items, should verify that <equals> method is not in use:
+        listBox.setValue(new CustomItem(3L, "Second"));
+
+        Assert.assertNotNull(listBox.getValue());
+        Assert.assertEquals(Long.valueOf(3L), listBox.getValue().getId());
+    }
+
+    @Test
+    public void withoutSettingIdentifierProvider_setItemWithNullId_shouldSelectCorrectItemBasedOnEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> listBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = listBox.setItems(items);
+
+        listBox.setValue(new CustomItem(null, "Second"));
+
+        Assert.assertNotNull(listBox.getValue());
+        Assert.assertEquals(Long.valueOf(2L), listBox.getValue().getId());
+    }
+
+    @Test
+    public void setIdentifierProviderOnId_setItemWithNullId_shouldThrowException() {
+
+        thrown.expect(NullPointerException.class);
+
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> listBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = listBox.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        listBox.setValue(new CustomItem(null, "First"));
     }
 
     private void assertDisabledItem(int index, boolean disabled) {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxUnitTest.java
@@ -1,10 +1,15 @@
 package com.vaadin.flow.component.listbox.test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.listbox.ListBox;
+import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 
 public class ListBoxUnitTest {
 
@@ -48,6 +53,40 @@ public class ListBoxUnitTest {
         assertDisabledItem(1, false);
     }
 
+    @Test
+    public void setIdentifierProvider_shouldSelectCorrectItem_dueToIdentifier() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> listBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = listBox.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        listBox.setValue(new CustomItem(1L));
+
+        Assert.assertNotNull(listBox.getValue());
+        Assert.assertEquals(listBox.getValue().getName(), "First");
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item not with the reference of existing item, but instead
+        // with just the Id:
+        listBox.setValue(new CustomItem(2L));
+
+        Assert.assertNotNull(listBox.getValue());
+        Assert.assertEquals(Long.valueOf(2L), listBox.getValue().getId());
+    }
+
     private void assertDisabledItem(int index, boolean disabled) {
         if (disabled) {
             Assert.assertNotNull(listBox.getElement().getChild(index)
@@ -57,5 +96,4 @@ public class ListBoxUnitTest {
                     .getAttribute("disabled"));
         }
     }
-
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -208,6 +208,47 @@ public class MultiSelectListBoxTest {
         multiSelectListBox.getListDataView();
     }
 
+    @Test
+    public void setIdentifierProvider_shouldSelectCorrectItems_dueToIdentifier() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        MultiSelectListBox<CustomItem> multiSelectListBox =
+                new MultiSelectListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = multiSelectListBox
+                .setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        multiSelectListBox.setValue(createSet(new CustomItem(1L)));
+
+        long[] selectedIds = multiSelectListBox.getSelectedItems().stream()
+                .mapToLong(CustomItem::getId)
+                .toArray();
+        Assert.assertArrayEquals(new long[] {1L}, selectedIds);
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item not with the reference of existing item, but instead
+        // with just the Id:
+        multiSelectListBox.setValue(Collections.singleton(new CustomItem(2L)));
+
+        selectedIds = multiSelectListBox.getSelectedItems()
+                .stream()
+                .mapToLong(CustomItem::getId)
+                .toArray();
+        Assert.assertArrayEquals(new long[] {2L}, selectedIds);
+    }
+
     private void assertValueChangeEvents(Set<Item>... expectedValues) {
         Assert.assertEquals(expectedValues.length, eventValues.size());
         IntStream.range(0, expectedValues.length).forEach(i -> {
@@ -270,5 +311,4 @@ public class MultiSelectListBoxTest {
             return name;
         }
     }
-
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/test/java/com/vaadin/flow/component/listbox/test/MultiSelectListBoxTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.listbox.ListBox;
 import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -209,7 +210,7 @@ public class MultiSelectListBoxTest {
     }
 
     @Test
-    public void setIdentifierProvider_shouldSelectCorrectItems_dueToIdentifier() {
+    public void setIdentifierProvider_setItemsWithIdentifierOnly_shouldSelectCorrectItem() {
         CustomItem first = new CustomItem(1L, "First");
         CustomItem second = new CustomItem(2L, "Second");
         CustomItem third = new CustomItem(3L, "Third");
@@ -247,6 +248,94 @@ public class MultiSelectListBoxTest {
                 .mapToLong(CustomItem::getId)
                 .toArray();
         Assert.assertArrayEquals(new long[] {2L}, selectedIds);
+    }
+
+    @Test
+    public void setIdentifierProvider_setItemWithIdAndWrongName_shouldSelectCorrectItemBasedOnIdNotEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        MultiSelectListBox<CustomItem> multiSelectListBox =
+                new MultiSelectListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = multiSelectListBox
+                .setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        multiSelectListBox.setValue(createSet(new CustomItem(1L)));
+
+        long[] selectedIds = multiSelectListBox.getSelectedItems().stream()
+                .mapToLong(CustomItem::getId)
+                .toArray();
+        Assert.assertArrayEquals(new long[] {1L}, selectedIds);
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item not with the reference of existing item, but instead
+        // with just the Id:
+        multiSelectListBox.setValue(Collections.singleton(
+                new CustomItem(3L, "Second")));
+
+        selectedIds = multiSelectListBox.getSelectedItems()
+                .stream()
+                .mapToLong(CustomItem::getId)
+                .toArray();
+        Assert.assertArrayEquals(new long[] {3L}, selectedIds);
+    }
+
+    @Test
+    public void withoutSettingIdentifierProvider_setItemWithNullId_shouldSelectCorrectItemBasedOnEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        MultiSelectListBox<CustomItem> multiSelectListBox =
+                new MultiSelectListBox<>();
+        ListBoxListDataView<CustomItem> listDataView =
+                multiSelectListBox.setItems(items);
+
+        multiSelectListBox.setValue(Collections.singleton(
+                new CustomItem( null,"Second")));
+
+        Assert.assertNotNull(multiSelectListBox.getValue());
+
+        long[] selectedIds =  multiSelectListBox.getSelectedItems().stream()
+                                .mapToLong(CustomItem::getId)
+                                .toArray();
+
+        Assert.assertArrayEquals(new long[] {2L}, selectedIds);
+    }
+
+    @Test
+    public void setIdentifierProviderOnId_setItemWithNullId_shouldThrowException() {
+
+        thrown.expect(NullPointerException.class);
+
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        ListBox<CustomItem> multiSelectListBox = new ListBox<>();
+        ListBoxListDataView<CustomItem> listDataView = multiSelectListBox
+                .setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        multiSelectListBox.setValue(new CustomItem(null, "First"));
     }
 
     private void assertValueChangeEvents(Set<Item>... expectedValues) {


### PR DESCRIPTION
Take IdentifierProvider into use for equality determination in `ListBox` and `MultiSelectListBox` by overriding `valueEquals`:
Fix: #225 
Fix: #227 
