### PR TITLE
fix: Keep HelperComponent after reset (14.4)

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/HelperPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/HelperPage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+
+import java.util.Set;
+
+@Route("vaadin-checkbox/helper")
+public class HelperPage extends Div {
+
+    public HelperPage() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        Span span = new Span("Helper text");
+        checkboxGroup.setHelperComponent(span);
+
+        checkboxGroup.setItems("foo", "bar", "baz");
+        Binder<Bean> binder = new Binder<>();
+        binder.bind(checkboxGroup, bean -> bean.choices,
+            (bean, value) -> bean.choices = value);
+        binder.setBean(new Bean());
+        add(checkboxGroup);
+    }
+
+    public static class Bean {
+        private Set<String> choices;
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/HelperIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.checkbox.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+
+@TestPath("vaadin-checkbox/helper")
+public class HelperIT extends AbstractComponentIT {
+
+    /**
+     * Assert that helper component exists after
+     * setItems.
+     * https://github.com/vaadin/vaadin-checkbox/issues/191
+     */
+    @Test
+    public void assertHelperComponentExists() {
+        open();
+        TestBenchElement checkboxGroup = $("vaadin-checkbox-group").first();
+
+        TestBenchElement helperComponent = checkboxGroup.$("span")
+            .attributeContains("slot", "helper").first();
+        Assert.assertEquals("Helper text", helperComponent.getText());
+
+    }
+}

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
@@ -333,9 +334,16 @@ public class CheckboxGroup<T>
     }
 
     private void reset() {
+        // Cache helper component before removal
+        Component helperComponent = getHelperComponent();
         keyMapper.removeAll();
         removeAll();
         clear();
+
+        // reinsert helper component
+        // see https://github.com/vaadin/vaadin-checkbox/issues/191
+        setHelperComponent(helperComponent);
+
         getDataProvider().fetch(new Query<>()).map(this::createCheckBox)
                 .forEach(this::add);
     }


### PR DESCRIPTION
Cherry-pick fix into 14.4

Fixes: vaadin/vaadin-checkbox#191

Web-component: checkbox