### PR TITLE
ci: Include root and component-parent into release parameter

### DIFF
--- a/scripts/prepareDeploy.sh
+++ b/scripts/prepareDeploy.sh
@@ -95,11 +95,11 @@ then
 fi
 
 echo "Deploying "`echo $modules | wc -w`" Modules from branch=$branch to profile=$profile"
-
-build=vaadin-flow-components-shared
+## '.' points to the root project, 'vaadin-flow-components-shared' has the dependencies for demo and tests 
+build=.,vaadin-flow-components-shared
 for i in $modules
 do
-  [ -d "$i" -o -d "$i-flow-parent" ] && build=$build,$i-flow-parent/$i-flow,$i-flow-parent/$i-testbench,$i-flow-parent/$i-flow-demo
+  [ -d "$i" -o -d "$i-flow-parent" ] && build=$build,$i-flow-parent,$i-flow-parent/$i-flow,$i-flow-parent/$i-testbench,$i-flow-parent/$i-flow-demo
 done
 
 ## Inform TC about computed parameters


### PR DESCRIPTION
currently, we have the `-am` parameter used in the component release build, 
as a side effect, if brings in unnecessary dependencies in the deploy list. 
To remove `-am`, we need to add the component parent project and root project 
into the `build.modules`