### PR TITLE
fix: Not to fire an item count change event on client filter change

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
@@ -47,6 +47,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-notification-flow</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.combobox.demo.entity.Element;
 import com.vaadin.flow.component.combobox.demo.entity.Person;
 import com.vaadin.flow.component.combobox.demo.entity.Project;
 import com.vaadin.flow.component.combobox.demo.entity.Song;
+import com.vaadin.flow.component.combobox.demo.entity.Ticket;
 import com.vaadin.flow.component.combobox.demo.service.PersonService;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
@@ -186,43 +187,46 @@ public class ComboBoxView extends DemoView {
     private void itemCountChangeNotification() {
         // begin-source-example
         // source-example-heading: Item Count Change Notification
-        ComboBox<String> comboBox = new ComboBox<>("Cars");
-        comboBox.setPlaceholder("Select a car to buy");
+        ComboBox<Ticket> comboBox = new ComboBox<>("Available tickets");
+        comboBox.setPlaceholder("Select a ticket");
 
-        ComboBoxListDataView<String> dataView = comboBox.setItems("Honda",
-                "Audi", "Tesla");
+        Collection<Ticket> tickets = generateTickets();
 
-        Button buyCarButton = new Button("Buy a car", click ->
+        ComboBoxListDataView<Ticket> dataView = comboBox.setItems(tickets);
+
+        Button buyTicketButton = new Button("Buy a ticket", click ->
                 comboBox.getOptionalValue().ifPresent(dataView::removeItem));
 
         /*
          * If you want to get notified when the ComboBox's items count has
-         * changed on the server side, i.e. due to adding or removing an
+         * changed on the server-side, i.e. due to adding or removing an
          * item(s), or by changing the server-side filtering, you can add a
          * listener using a data view API.
          *
-         * Please note that the ComboBox's client filter change won't fire
-         * the event, since it doesn't change the item count
-         * on the server side, but only reduces the item list in UI and makes
-         * it easier to search through the items.
+         * Please note that the ComboBox's client-side filter change won't fire
+         * the event, since it doesn't change the item count on the server-side,
+         * but only reduces the item list in UI and makes it easier to search
+         * through the items.
          */
-        dataView.addItemCountChangeListener(event ->
-                comboBox.getOptionalValue().ifPresent(car -> {
+        dataView.addItemCountChangeListener(
+                event -> comboBox.getOptionalValue().ifPresent(ticket -> {
                     if (event.getItemCount() > 0) {
                         Notification.show(String.format(
-                                "%s is sold. Hurry, only %d car(s) left", car,
-                                event.getItemCount()), 3000,
+                                "Ticket with %s is sold. %d ticket(s) left",
+                                ticket, event.getItemCount()), 3000,
                                 Notification.Position.MIDDLE);
                     } else {
-                        Notification.show("All cars were sold out, come next week", 3000,
-                                Notification.Position.MIDDLE);
-                        buyCarButton.setEnabled(false);
+                        Notification.show(
+                                "All tickets were sold out",
+                                3000, Notification.Position.MIDDLE);
+                        buyTicketButton.setEnabled(false);
                     }
                     comboBox.clear();
                 }));
         // end-source-example
 
-        HorizontalLayout layout = new HorizontalLayout(comboBox, buyCarButton);
+        HorizontalLayout layout = new HorizontalLayout(comboBox,
+                buyTicketButton);
         layout.setAlignItems(FlexComponent.Alignment.BASELINE);
         addCard("Item Count Change Notification", layout);
     }
@@ -702,6 +706,16 @@ public class ComboBoxView extends DemoView {
         listOfSongs.add(
                 new Song("Voices of a Distant Star", "Killigrew", "Animus II"));
         return listOfSongs;
+    }
+
+    private Collection<Ticket> generateTickets() {
+        Collection<Ticket> tickets = new ArrayList<>();
+        for (int row = 1; row < 51; row++) {
+            for (int seat = 1; seat < 51; seat++) {
+                tickets.add(new Ticket(row, seat));
+            }
+        }
+        return tickets;
     }
 
     private Div createMessageDiv(String id) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
@@ -39,6 +39,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -73,6 +74,7 @@ public class ComboBoxView extends DemoView {
         customValues();
         storingCustomValues();
         autoOpenDisabled();
+        itemCountChangeNotification();
         lazyLoading(); // Lazy loading
         lazyLoadingWithExactItemCount();
         lazyLoadingWithCustomItemCountEstimate();
@@ -179,6 +181,50 @@ public class ComboBoxView extends DemoView {
         // end-source-example
 
         addCard("Auto open disabled", note, comboBox);
+    }
+
+    private void itemCountChangeNotification() {
+        // begin-source-example
+        // source-example-heading: Item Count Change Notification
+        ComboBox<String> comboBox = new ComboBox<>("Cars");
+        comboBox.setPlaceholder("Select a car to buy");
+
+        ComboBoxListDataView<String> dataView = comboBox.setItems("Honda",
+                "Audi", "Tesla");
+
+        Button buyCarButton = new Button("Buy a car", click ->
+                comboBox.getOptionalValue().ifPresent(dataView::removeItem));
+
+        /*
+         * If you want to get notified when the ComboBox's items count has
+         * changed on the server side, i.e. due to adding or removing an
+         * item(s), or by changing the server-side filtering, you can add a
+         * listener using a data view API.
+         *
+         * Please note that the ComboBox's client filter change won't fire
+         * the event, since it doesn't change the item count
+         * on the server side, but only reduces the item list in UI and makes
+         * it easier to search through the items.
+         */
+        dataView.addItemCountChangeListener(event ->
+                comboBox.getOptionalValue().ifPresent(car -> {
+                    if (event.getItemCount() > 0) {
+                        Notification.show(String.format(
+                                "%s is sold. Hurry, only %d car(s) left", car,
+                                event.getItemCount()), 3000,
+                                Notification.Position.MIDDLE);
+                    } else {
+                        Notification.show("All cars were sold out, come next week", 3000,
+                                Notification.Position.MIDDLE);
+                        buyCarButton.setEnabled(false);
+                    }
+                    comboBox.clear();
+                }));
+        // end-source-example
+
+        HorizontalLayout layout = new HorizontalLayout(comboBox, buyCarButton);
+        layout.setAlignItems(FlexComponent.Alignment.BASELINE);
+        addCard("Item Count Change Notification", layout);
     }
 
     private void valueChangeEvent() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/entity/Ticket.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/src/main/java/com/vaadin/flow/component/combobox/demo/entity/Ticket.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.component.combobox.demo.entity;
+
+public class Ticket {
+
+    private int row;
+    private int seat;
+
+    public Ticket(int row, int seat) {
+        this.row = row;
+        this.seat = seat;
+    }
+
+    public int getRow() {
+        return row;
+    }
+
+    public int getSeat() {
+        return seat;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Row %d / Seat %d", row, seat);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterIT.java
@@ -125,10 +125,8 @@ public class ClientSideFilterIT extends AbstractComboBoxIT {
 
         waitForItems(comboBox, items -> items.size() == 19);
 
-        // TODO: client filter should not fire the item count change event
-        //  https://github.com/vaadin/vaadin-flow-components/issues/210
-        Assert.assertEquals("Expected 19 items after filtering", 19,
-                getItemCount(IN_MEMORY_COMBO_BOX_ITEM_COUNT_SPAN_ID));
+        Assert.assertEquals("Expected no item count change events on client filter change",
+                100, getItemCount(IN_MEMORY_COMBO_BOX_ITEM_COUNT_SPAN_ID));
     }
 
     @Test
@@ -150,10 +148,9 @@ public class ClientSideFilterIT extends AbstractComboBoxIT {
 
         waitForItems(comboBox, items -> items.size() == 12);
 
-        // TODO: client filter should not fire the item count change event
-        //  https://github.com/vaadin/vaadin-flow-components/issues/210
-        Assert.assertEquals("Expected 12 items after filtering", 12,
-                getItemCount(BACKEND_COMBO_BOX_ITEM_COUNT_SPAN_ID));
+        Assert.assertEquals(
+                "Expected no item count change events on client filter change",
+                30, getItemCount(BACKEND_COMBO_BOX_ITEM_COUNT_SPAN_ID));
     }
 
     private int getItemCount(String id) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -1523,8 +1523,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             String filter = lastFilter;
             lastFilter = null;
             /*
-             * Call to 'DataCommunicator::reset' is done inside the filter
-             * slot callback, so we don't need to explicitly call it.
+             * This filter slot will eventually call the filter consumer in
+             * data communicator and 'DataCommunicator::reset' is done inside
+             * this consumer, so we don't need to explicitly call it.
              */
             filterSlot.accept(filter);
         }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -858,13 +858,16 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             return filterConverter.apply(filterText);
         };
 
-        SerializableConsumer<C> providerFilterSlot = dataCommunicator
+        SerializableConsumer<DataCommunicator.Filter<C>> providerFilterSlot = dataCommunicator
                 .setDataProvider(dataProvider,
-                        convertOrNull.apply(getFilterString()));
+                        convertOrNull.apply(getFilterString()), false);
 
         filterSlot = filter -> {
             if (!Objects.equals(filter, lastFilter)) {
-                providerFilterSlot.accept(convertOrNull.apply(filter));
+                DataCommunicator.Filter<C> objectFilter =
+                        new DataCommunicator.Filter<C>(
+                                convertOrNull.apply(filter), filter.isEmpty());
+                providerFilterSlot.accept(objectFilter);
                 lastFilter = filter;
             }
         };
@@ -1507,7 +1510,24 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @ClientCallable
     private void resetDataCommunicator() {
-        dataCommunicator.reset();
+        /*
+         * The client filter from combo box will be used in the data
+         * communicator only within 'setRequestedRange' calls to data provider,
+         * and then will be erased to not affect the data view item count
+         * handling methods. Thus, if the current client filter is not empty,
+         * then we need to re-set it in the data communicator.
+         */
+        if (lastFilter == null || lastFilter.isEmpty()) {
+            dataCommunicator.reset();
+        } else {
+            String filter = lastFilter;
+            lastFilter = null;
+            /*
+             * Call to 'DataCommunicator::reset' is done inside the filter
+             * slot callback, so we don't need to explicitly call it.
+             */
+            filterSlot.accept(filter);
+        }
     }
 
     void runBeforeClientResponse(SerializableConsumer<UI> command) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
@@ -57,8 +57,25 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
         this.dataCommunicator = dataCommunicator;
     }
 
+    /**
+     * Gets the item at the given index from the data available in the
+     * ComboBox's server-side.
+     * <p>
+     * This method does not take into account the ComboBox client filtering,
+     * since it doesn't change the item count on the server side, but only
+     * makes it easier for users to search through the items in the UI.
+     *
+     * @param index
+     *            item index number
+     * @return item on index
+     * @throws IndexOutOfBoundsException
+     *             requested index is outside of the data set
+     */
     @Override
     public T getItem(int index) {
+        // TODO: change the implementation to make the returned item not depend
+        //  on client filter applied
+        //  https://github.com/vaadin/vaadin-flow-components/issues/282
         return dataCommunicator.getItem(index);
     }
 
@@ -67,6 +84,15 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
         return DataProvider.class;
     }
 
+    /**
+     * Gets the items available on the ComboBox's server side.
+     * <p>
+     * This method does not take into account the ComboBox client filtering,
+     * since it doesn't change the item count on the server side, but only
+     * makes it easier for users to search through the items in the UI.
+     *
+     * @return items available on the server side
+     */
     @Override
     public Stream<T> getItems() {
         return dataCommunicator.getDataProvider()
@@ -84,8 +110,13 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
      * {@inheritDoc}
      * <p>
      * Combo box fires {@link ItemCountChangeEvent} and notifies all the
-     * listeners added by this method, if the items count changed due to combo
-     * box's client filter applied by user.
+     * listeners added by this method, if the items count changed, for
+     * instance, due to adding or removing an item(s).
+     * <p>
+     * ComboBox's client filter change won't fire
+     * {@link ItemCountChangeEvent}, since it doesn't change the item count
+     * on the server side, but only makes it easier for users to search
+     * through the items in the UI.
      */
     @Override
     public Registration addItemCountChangeListener(

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
@@ -61,9 +61,9 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
      * Gets the item at the given index from the data available in the
      * ComboBox's server-side.
      * <p>
-     * This method does not take into account the ComboBox client filtering,
-     * since it doesn't change the item count on the server side, but only
-     * makes it easier for users to search through the items in the UI.
+     * This method does not take into account the ComboBox client-side
+     * filtering, since it doesn't change the item count on the server-side,
+     * but only makes it easier for users to search through the items in the UI.
      *
      * @param index
      *            item index number
@@ -74,7 +74,7 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
     @Override
     public T getItem(int index) {
         // TODO: change the implementation to make the returned item not depend
-        //  on client filter applied
+        //  on client-side filter applied
         //  https://github.com/vaadin/vaadin-flow-components/issues/282
         return dataCommunicator.getItem(index);
     }
@@ -85,13 +85,13 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
     }
 
     /**
-     * Gets the items available on the ComboBox's server side.
+     * Gets the items available on the ComboBox's server-side.
      * <p>
-     * This method does not take into account the ComboBox client filtering,
-     * since it doesn't change the item count on the server side, but only
-     * makes it easier for users to search through the items in the UI.
+     * This method does not take into account the ComboBox client-side
+     * filtering, since it doesn't change the item count on the server-side,
+     * but only makes it easier for users to search through the items in the UI.
      *
-     * @return items available on the server side
+     * @return items available on the server-side
      */
     @Override
     public Stream<T> getItems() {
@@ -113,9 +113,9 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
      * listeners added by this method, if the items count changed, for
      * instance, due to adding or removing an item(s).
      * <p>
-     * ComboBox's client filter change won't fire
+     * ComboBox's client-side filter change won't fire
      * {@link ItemCountChangeEvent}, since it doesn't change the item count
-     * on the server side, but only makes it easier for users to search
+     * on the server-side, but only makes it easier for users to search
      * through the items in the UI.
      */
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
@@ -115,9 +115,9 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
      * instance, due to fetching more items while scrolling with unknown item
      * count.
      * <p>
-     * ComboBox's client filter change won't fire
+     * ComboBox's client-side filter change won't fire
      * {@link ItemCountChangeEvent}, since it doesn't change the item count
-     * on the server side, but only makes it easier for users to search
+     * on the server-side, but only makes it easier for users to search
      * through the items in the UI.
      */
     @Override
@@ -130,9 +130,9 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
      * Gets the item at the given index from the data available in the
      * ComboBox's server-side.
      * <p>
-     * This method does not take into account the ComboBox client filtering,
-     * since it doesn't change the item count on the server side, but only
-     * makes it easier for users to search through the items in the UI.
+     * This method does not take into account the ComboBox client-side
+     * filtering, since it doesn't change the item count on the server-side,
+     * but only makes it easier for users to search through the items in the UI.
      *
      * @param index
      *            item index number
@@ -143,24 +143,24 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
     @Override
     public T getItem(int index) {
         // TODO: change the implementation to make the returned item not depend
-        //  on client filter applied
+        //  on client-side filter applied
         //  https://github.com/vaadin/vaadin-flow-components/issues/282
         return super.getItem(index);
     }
 
     /**
-     * Gets the items available on the ComboBox's server side.
+     * Gets the items available on the ComboBox's server-side.
      * <p>
-     * This method does not take into account the ComboBox client filtering,
-     * since it doesn't change the item count on the server side, but only
+     * This method does not take into account the ComboBox client-filtering,
+     * since it doesn't change the item count on the server-side, but only
      * makes it easier for users to search through the items in the UI.
      *
-     * @return items available on the server side
+     * @return items available on the server-side
      */
     @Override
     public Stream<T> getItems() {
         // TODO: change the implementation to make the returned item not depend
-        //  on client filter applied
+        //  on client-side filter applied
         //  https://github.com/vaadin/vaadin-flow-components/issues/282
         return super.getItems();
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
@@ -16,6 +16,8 @@
 
 package com.vaadin.flow.component.combobox.dataview;
 
+import java.util.stream.Stream;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.data.provider.AbstractLazyDataView;
@@ -109,12 +111,57 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
      * {@inheritDoc}
      * <p>
      * Combo box fires {@link ItemCountChangeEvent} and notifies all the
-     * listeners added by this method, if the items count changed due to combo
-     * box's client filter applied by user.
+     * listeners added by this method, if the items count changed, for
+     * instance, due to fetching more items while scrolling with unknown item
+     * count.
+     * <p>
+     * ComboBox's client filter change won't fire
+     * {@link ItemCountChangeEvent}, since it doesn't change the item count
+     * on the server side, but only makes it easier for users to search
+     * through the items in the UI.
      */
     @Override
     public Registration addItemCountChangeListener(
             ComponentEventListener<ItemCountChangeEvent<?>> listener) {
         return super.addItemCountChangeListener(listener);
+    }
+
+    /**
+     * Gets the item at the given index from the data available in the
+     * ComboBox's server-side.
+     * <p>
+     * This method does not take into account the ComboBox client filtering,
+     * since it doesn't change the item count on the server side, but only
+     * makes it easier for users to search through the items in the UI.
+     *
+     * @param index
+     *            item index number
+     * @return item on index
+     * @throws IndexOutOfBoundsException
+     *             requested index is outside of the data set
+     */
+    @Override
+    public T getItem(int index) {
+        // TODO: change the implementation to make the returned item not depend
+        //  on client filter applied
+        //  https://github.com/vaadin/vaadin-flow-components/issues/282
+        return super.getItem(index);
+    }
+
+    /**
+     * Gets the items available on the ComboBox's server side.
+     * <p>
+     * This method does not take into account the ComboBox client filtering,
+     * since it doesn't change the item count on the server side, but only
+     * makes it easier for users to search through the items in the UI.
+     *
+     * @return items available on the server side
+     */
+    @Override
+    public Stream<T> getItems() {
+        // TODO: change the implementation to make the returned item not depend
+        //  on client filter applied
+        //  https://github.com/vaadin/vaadin-flow-components/issues/282
+        return super.getItems();
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -55,11 +55,11 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
     }
 
     /**
-     * Gets the items available on the ComboBox's server side.
+     * Gets the items available on the ComboBox's server-side.
      * <p>
      * Data is sorted the same way as in the ComboBox, but it does not take
-     * into account the ComboBox client filtering, since it doesn't change
-     * the item count on the server side, but only makes it easier for users
+     * into account the ComboBox client-side filtering, since it doesn't change
+     * the item count on the server-side, but only makes it easier for users
      * to search through the items in the UI.
      * Only the server-side filtering considered, which is set by:
      * {@link #setFilter(SerializablePredicate)} or
@@ -80,8 +80,8 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
      * is set by:
      * {@link #setFilter(SerializablePredicate)} or
      * {@link #addFilter(SerializablePredicate)}.
-     * ComboBox's client filter is not considered, since it doesn't change
-     * the item count on the server side, but only makes it easier for users
+     * ComboBox's client-side filter is not considered, since it doesn't change
+     * the item count on the server-side, but only makes it easier for users
      * to search through the items in the UI.
      *
      * @return filtered item count
@@ -108,9 +108,9 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
      * with {@link #setFilter(SerializablePredicate)} or
      * {@link #addFilter(SerializablePredicate)}.
      * <p>
-     * ComboBox's client filter change won't fire
+     * ComboBox's client-side filter change won't fire
      * {@link ItemCountChangeEvent}, since it doesn't change the item count
-     * on the server side, but only makes it easier for users to search
+     * on the server-side, but only makes it easier for users to search
      * through the items in the UI.
      */
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.ItemCountChangeEvent;
 import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -53,12 +54,38 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
         this.dataCommunicator = dataCommunicator;
     }
 
+    /**
+     * Gets the items available on the ComboBox's server side.
+     * <p>
+     * Data is sorted the same way as in the ComboBox, but it does not take
+     * into account the ComboBox client filtering, since it doesn't change
+     * the item count on the server side, but only makes it easier for users
+     * to search through the items in the UI.
+     * Only the server-side filtering considered, which is set by:
+     * {@link #setFilter(SerializablePredicate)} or
+     * {@link #addFilter(SerializablePredicate)}.
+     *
+     * @return filtered and sorted items available in server-side
+     */
     @SuppressWarnings("unchecked")
     @Override
     public Stream<T> getItems() {
         return getDataProvider().fetch(getQuery());
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method takes into account only the server-side filtering, which
+     * is set by:
+     * {@link #setFilter(SerializablePredicate)} or
+     * {@link #addFilter(SerializablePredicate)}.
+     * ComboBox's client filter is not considered, since it doesn't change
+     * the item count on the server side, but only makes it easier for users
+     * to search through the items in the UI.
+     *
+     * @return filtered item count
+     */
     @SuppressWarnings("unchecked")
     @Override
     public int getItemCount() {
@@ -76,8 +103,15 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
      * {@inheritDoc}
      * <p>
      * Combo box fires {@link ItemCountChangeEvent} and notifies all the
-     * listeners added by this method, if the items count changed due to combo
-     * box's client filter applied by user.
+     * listeners added by this method, if the items count changed due to
+     * adding or removing an item(s), or by changing the server-side filtering
+     * with {@link #setFilter(SerializablePredicate)} or
+     * {@link #addFilter(SerializablePredicate)}.
+     * <p>
+     * ComboBox's client filter change won't fire
+     * {@link ItemCountChangeEvent}, since it doesn't change the item count
+     * on the server side, but only makes it easier for users to search
+     * through the items in the UI.
      */
     @Override
     public Registration addItemCountChangeListener(

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.ItemCountChangeEvent;
+import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -52,15 +53,16 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
         this.dataCommunicator = dataCommunicator;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Stream<T> getItems() {
-        return getDataProvider().fetch(dataCommunicator.buildQuery(0,
-                Integer.MAX_VALUE));
+        return getDataProvider().fetch(getQuery());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public int getItemCount() {
-        return dataCommunicator.getItemCount();
+        return getDataProvider().size(getQuery());
     }
 
     @Override
@@ -81,5 +83,10 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
     public Registration addItemCountChangeListener(
             ComponentEventListener<ItemCountChangeEvent<?>> listener) {
         return super.addItemCountChangeListener(listener);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Query getQuery() {
+        return dataCommunicator.buildQuery(0, Integer.MAX_VALUE);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -93,7 +93,6 @@ public class ComboBoxLazyDataViewTest {
         }, arrayUpdater, null, comboBox.getElement().getNode());
 
         dataCommunicator.setDataProvider(dataProvider, null);
-        dataCommunicator.setPageSize(50);
 
         dataView = new ComboBoxLazyDataView<>(dataCommunicator, comboBox);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -24,21 +24,15 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.data.provider.ArrayUpdater;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
-import com.vaadin.flow.data.provider.DataProvider;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.data.provider.AbstractListDataViewListenerTest;
 import com.vaadin.flow.data.provider.DataCommunicator;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.HasListDataView;
-import org.mockito.Mockito;
-
-import elemental.json.JsonValue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
 
@@ -46,7 +40,6 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     private ComboBoxListDataView<String> dataView;
     private ComboBox<String> component;
     private DataCommunicatorTest.MockUI ui;
-    private DataCommunicator<String> dataCommunicator;
 
     @Before
     public void init() {
@@ -55,35 +48,7 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         ui = new DataCommunicatorTest.MockUI();
         ui.add(component);
 
-        ArrayUpdater.Update update = new ArrayUpdater.Update() {
-
-            @Override
-            public void clear(int start, int length) {
-
-            }
-
-            @Override
-            public void set(int start, List<JsonValue> items) {
-
-            }
-
-            @Override
-            public void commit(int updateId) {
-
-            }
-        };
-
-        ArrayUpdater arrayUpdater = Mockito.mock(ArrayUpdater.class);
-        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt()))
-                .thenReturn(update);
-
-        dataCommunicator = new DataCommunicator<>((item, jsonObject) -> {
-        }, arrayUpdater, null, component.getElement().getNode());
-
-        dataCommunicator.setDataProvider(DataProvider.ofCollection(items),
-                null);
-
-        dataView = new ComboBoxListDataView<>(dataCommunicator, component);
+        dataView = component.setItems(items);
     }
 
     @Test
@@ -94,43 +59,9 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     }
 
     @Test
-    public void getItems_withTextFilter_filteredItemsObtained() {
-        ComboBox<String> comboBox = getDefaultLocaleComboBox();
-        ComboBoxListDataView<String> dataView = comboBox.setItems(items);
-        setClientFilter(comboBox, "middle");
-        Stream<String> filteredItems = dataView.getItems();
-        Assert.assertArrayEquals("Unexpected data set",
-                new String[] { "middle" }, filteredItems.toArray());
-
-        // Remove the filters
-        setClientFilter(comboBox, "");
-        filteredItems = dataView.getItems();
-        Assert.assertArrayEquals("Unexpected data set",
-                new String[] { "first", "middle", "last" },
-                filteredItems.toArray());
-    }
-
-    @Test
-    public void getItems_withInMemoryFilter_filteredItemsObtained() {
-        dataView.setFilter("middle"::equals);
-        Stream<String> filteredItems = dataView.getItems();
-        Assert.assertArrayEquals("Unexpected data set",
-                new String[] { "middle" }, filteredItems.toArray());
-
-        // Remove the filters
-        dataView.removeFilters();
-        filteredItems = dataView.getItems();
-        Assert.assertArrayEquals("Unexpected data set",
-                new String[] { "first", "middle", "last" },
-                filteredItems.toArray());
-    }
-
-    @Test
     public void getItems_withInMemoryAndTextFilter_itemsFilteredWithOnlyInMemoryFilter() {
         items = Arrays.asList("foo", "bar", "banana");
-        dataCommunicator.setDataProvider(DataProvider.ofCollection(items),
-                null);
-        dataView = new ComboBoxListDataView<>(dataCommunicator, component);
+        dataView = component.setItems(items);
 
         setClientFilter(component, "ba");
         fakeClientCommunication();
@@ -162,13 +93,31 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     }
 
     @Test
-    public void getItemCount_withFilter_totalItemsCountObtained() {
-        dataView.setFilter(item -> item.equalsIgnoreCase("middle"));
+    public void getItemCount_withInMemoryAndTextFilter_itemsFilteredWithOnlyInMemoryFilter() {
+        items = Arrays.asList("foo", "bar", "banana");
+        dataView = component.setItems(items);
 
-        Assert.assertEquals("Unexpected item count", 1,
-                dataView.getItemCount());
+        setClientFilter(component, "ba");
+        fakeClientCommunication();
 
-        Assert.assertTrue("Unexpected item", dataView.contains(items.get(1)));
+        int itemCount = dataView.getItemCount();
+
+        // Check that the client filter does not affect the item count
+        Assert.assertEquals(
+                "The client filter shouldn't impact the items count",
+                3, itemCount);
+
+        dataView.setFilter(item -> item.length() == 3);
+        itemCount = dataView.getItemCount();
+        Assert.assertEquals("Unexpected item count after server side filter",
+                2, itemCount);
+
+        // Remove the filters
+        dataView.removeFilters();
+        itemCount = dataView.getItemCount();
+        Assert.assertEquals(
+                "Unexpected item count after removing server side filter",
+                3, itemCount);
     }
 
     @Test


### PR DESCRIPTION
Web-component: vaadin-combo-box

The combo-box client filter now does not affect the items handling API of in-memory data view, i.e. the item count change event is not triggered and 'getItems' does not use the client filter.

Fixes https://github.com/vaadin/vaadin-flow-components/issues/210