### PR TITLE
chore: remove the outdate the workaround

### DIFF
--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/src/main/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/src/main/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
@@ -44,8 +44,6 @@ import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 
-// FIXME remove once https://github.com/vaadin/flow/pull/5660 is available 
-@NpmPackage(value = "@vaadin/vaadin-lumo-styles", version = "1.5.0")
 @Route("iron-list")
 public class IronListView extends DemoView {
 


### PR DESCRIPTION
The linked ticket has been merged and closed. 