### PR TITLE
fix: add missing window prefix in the comboBoxConnector

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -21,7 +21,7 @@ import { ComboBoxPlaceholder } from '@vaadin/vaadin-combo-box/src/vaadin-combo-b
             const pageCallbacks = {};
             let cache = {};
             let lastFilter = '';
-            const placeHolder = new Vaadin.ComboBoxPlaceholder();
+            const placeHolder = new window.Vaadin.ComboBoxPlaceholder();
             const MAX_RANGE_COUNT = Math.max(comboBox.pageSize * 2, 500); // Max item count in active range
 
             const serverFacade = (() => {


### PR DESCRIPTION
This fixes

````
ERROR #98123  WEBPACK
Generating development JavaScript bundle failed

...flow-frontend/comboBoxConnector.js
   24:37  error    'Vaadin' is not defined                no-undef
```