### PR TITLE
feat: Use IdentifierProvider for equality in radio-button-group

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPage.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
@@ -33,6 +34,7 @@ public class RadioButtonGroupDataViewPage extends Div {
     static final String RADIO_GROUP_FOR_FILTER_DATA_VIEW = "radio-group-for-filter-data-view";
     static final String RADIO_GROUP_FOR_NEXT_PREV_DATA_VIEW = "radio-group-for-next-prev-data-view";
     static final String RADIO_GROUP_FOR_SORT_DATA_VIEW = "radio-group-for-sort-data-view";
+    static final String RADIO_GROUP_SELECTED_ID_SPAN = "radio-group-for-selected-ids-span";
 
     static final String DATA_VIEW_UPDATE_BUTTON = "data-view-update-button";
     static final String LIST_DATA_VIEW_UPDATE_BUTTON = "list-data-view-update-button";
@@ -44,10 +46,13 @@ public class RadioButtonGroupDataViewPage extends Div {
     static final String LIST_DATA_VIEW_NEXT_BUTTON = "list-data-view-next-button";
     static final String LIST_DATA_VIEW_PREV_BUTTON = "list-data-view-prev-button";
     static final String LIST_DATA_VIEW_SORT_BUTTON = "list-data-view-sort-button";
+    static final String RADIO_GROUP_SELECTION_BY_ID_UPDATE_BUTTON = "radio-group-selection-by-id-update-button";
+    static final String RADIO_GROUP_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON = "radio-group-selection-by-id-and-name-update-button";
 
     static final String CURRENT_ITEM_SPAN = "current-item-span";
     static final String HAS_NEXT_ITEM_SPAN = "has-next-item-span";
     static final String HAS_PREV_ITEM_SPAN = "has-prev-item-span";
+
 
     public RadioButtonGroupDataViewPage() {
         createGenericDataView();
@@ -57,6 +62,7 @@ public class RadioButtonGroupDataViewPage extends Div {
         createFilterItemsByDataView();
         createNextPreviousItemDataView();
         createSetSortComparatorDataView();
+        createIdentifierProviderForListBox();
     }
 
     private void createGenericDataView() {
@@ -235,6 +241,63 @@ public class RadioButtonGroupDataViewPage extends Div {
         add(rbgForSortDataView, dataViewSortButton);
     }
 
+    private void createIdentifierProviderForListBox() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        RadioButtonGroup<CustomItem> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> listDataView =
+                radioButtonGroup.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        radioButtonGroup.setValue(new CustomItem(3L));
+
+        Span selectedIdSpan = new Span();
+        selectedIdSpan.setId(RADIO_GROUP_SELECTED_ID_SPAN);
+        selectedIdSpan.setText(String.valueOf(radioButtonGroup.getValue().getId()));
+
+        Button updateAndSelectByIdOnlyButton =
+                new Button("Update & Select by Id", click -> {
+                    // Make the names of unselected items similar to the name of
+                    // selected one to mess with the <equals> implementation in
+                    // CustomItem:
+                    first.setName("Second");
+                    listDataView.refreshItem(first);
+
+                    third.setName("Second");
+                    listDataView.refreshItem(third);
+
+                    // Select the item not with the reference of existing item,
+                    // and instead with just the Id:
+                    radioButtonGroup.setValue(new CustomItem(2L));
+
+                    selectedIdSpan.setText(String.valueOf(
+                            radioButtonGroup.getValue().getId()));
+                });
+        updateAndSelectByIdOnlyButton
+                .setId(RADIO_GROUP_SELECTION_BY_ID_UPDATE_BUTTON);
+
+        Button selectByIdAndNameButton =
+                new Button("Select by Id and Name", click -> {
+                    // Select the item with the Id and a challenging wrong name
+                    // to verify <equals> method is not in use:
+                    radioButtonGroup.setValue(new CustomItem(3L, "Second"));
+
+                    selectedIdSpan.setText(
+                            String.valueOf(radioButtonGroup.getValue().getId()));
+                });
+        selectByIdAndNameButton
+                .setId(RADIO_GROUP_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON);
+
+        add(radioButtonGroup, selectedIdSpan, updateAndSelectByIdOnlyButton,
+                selectByIdAndNameButton);
+    }
+
     private static class GenericDataProvider
             extends AbstractDataProvider<Item, Void> {
         private final transient List<Item> items;
@@ -306,6 +369,45 @@ public class RadioButtonGroupDataViewPage extends Div {
 
         public String toString() {
             return String.valueOf(this.value);
+        }
+    }
+
+    private static class CustomItem {
+        private Long id;
+        private String name;
+
+        public CustomItem(Long id) {
+            this(id, null);
+        }
+
+        public CustomItem(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof CustomItem)) return false;
+            CustomItem that = (CustomItem) o;
+            return Objects.equals(getName(), that.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName());
         }
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPageIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPageIT.java
@@ -30,6 +30,9 @@ import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataVi
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_LIST_DATA_VIEW;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_SORT_DATA_VIEW;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_SELECTED_ID_SPAN;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_SELECTION_BY_ID_UPDATE_BUTTON;
 
 @TestPath("vaadin-radio-button/radio-Button-group-data-view")
 public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
@@ -233,4 +236,26 @@ public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
                 "third", buttons.get(2).getText());
     }
 
+    @Test
+    public void setIdentifierProvider_setItem_shouldSelectCorrectItemBasedOnIdentifier() {
+        WebElement selectedIdsSpan = findElement(
+                By.id(RADIO_GROUP_SELECTED_ID_SPAN));
+        Assert.assertEquals("Selected item id should be", "3",
+                selectedIdsSpan.getText());
+
+        findElement(By.id(RADIO_GROUP_SELECTION_BY_ID_UPDATE_BUTTON)).click();
+
+        selectedIdsSpan = findElement(
+                By.id(RADIO_GROUP_SELECTED_ID_SPAN));
+        Assert.assertEquals("Selected item ids should be", "2",
+                selectedIdsSpan.getText());
+
+        findElement(By.id(RADIO_GROUP_SELECTION_BY_ID_AND_NAME_UPDATE_BUTTON))
+                .click();
+
+        selectedIdsSpan = findElement(
+                By.id(RADIO_GROUP_SELECTED_ID_SPAN));
+        Assert.assertEquals("Selected item ids should be", "3",
+                selectedIdsSpan.getText());
+    }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -176,7 +176,8 @@ public class RadioButtonGroup<T>
      */
     @Override
     public RadioButtonGroupListDataView<T> getListDataView() {
-        return new RadioButtonGroupListDataView<>(this::getDataProvider, this);
+        return new RadioButtonGroupListDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
     /**
@@ -189,7 +190,8 @@ public class RadioButtonGroup<T>
      */
     @Override
     public RadioButtonGroupDataView<T> getGenericDataView() {
-        return new RadioButtonGroupDataView<>(this::getDataProvider, this);
+        return new RadioButtonGroupDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
 
@@ -513,6 +515,30 @@ public class RadioButtonGroup<T>
         }
     }
 
+    /**
+     * Compares two value instances to each other to determine whether they are
+     * equal. Equality is used to determine whether to update internal state and
+     * fire an event when {@link #setValue(Object)} or
+     * {@link #setModelValue(Object, boolean)} is called. Subclasses can
+     * override this method to define an alternative comparison method instead
+     * of {@link Objects#equals(Object)}.
+     *
+     * @param value1
+     *            the first instance
+     * @param value2
+     *            the second instance
+     * @return <code>true</code> if the instances are equal; otherwise
+     *         <code>false</code>
+     */
+    @Override
+    protected boolean valueEquals(T value1, T value2) {
+        if (value1 == null && value2 == null)
+            return true;
+        if (value1 == null || value2 == null)
+            return false;
+        return getItemId(value1).equals(getItemId(value2));
+    }
+
     private void updateEnabled(RadioButton<T> button) {
         boolean disabled = isDisabledBoolean()
                 || !getItemEnabledProvider().test(button.getItem());
@@ -541,5 +567,9 @@ public class RadioButtonGroup<T>
         }
         validationRegistration = getElement().addPropertyChangeListener("value",
                 validationListener);
+    }
+
+    private void identifierProviderChanged(IdentifierProvider<T> identifierProvider) {
+        keyMapper.setIdentifierGetter(identifierProvider);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -538,10 +538,12 @@ public class RadioButtonGroup<T>
      */
     @Override
     protected boolean valueEquals(T value1, T value2) {
-        if (value1 == null && value2 == null)
+        if (value1 == null && value2 == null) {
             return true;
-        if (value1 == null || value2 == null)
+        }
+        if (value1 == null || value2 == null) {
             return false;
+        }
         return getItemId(value1).equals(getItemId(value2));
     }
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.radiobutton.dataview;
 
-import java.util.Optional;
-
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -94,7 +92,8 @@ public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
@@ -93,7 +93,8 @@ public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
     public void setIdentifierProvider(
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
-        Optional.of(identifierChangedCallback)
-                .ifPresent(callback -> callback.accept(identifierProvider));
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.radiobutton.dataview;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -91,6 +93,7 @@ public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
     public void setIdentifierProvider(
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
-        identifierChangedCallback.accept(identifierProvider);
+        Optional.of(identifierChangedCallback)
+                .ifPresent(callback -> callback.accept(identifierProvider));
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupDataView.java
@@ -18,7 +18,9 @@ package com.vaadin.flow.component.radiobutton.dataview;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -29,6 +31,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * @since
  */
 public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Constructs a new DataView.
@@ -42,6 +46,25 @@ public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             RadioButtonGroup radioButtonGroup) {
         super(dataProviderSupplier, radioButtonGroup);
+    }
+
+    /**
+     * Constructs a new DataView.
+     *
+     * @param dataProviderSupplier
+     *            data provider supplier
+     * @param radioButtonGroup
+     *            radioButton group instance for this DataView
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public RadioButtonGroupDataView(
+            SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
+            RadioButtonGroup radioButtonGroup,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup);
+        this.identifierChangedCallback = identifierChangedCallback;
     }
 
     @Override
@@ -62,5 +85,12 @@ public class RadioButtonGroupDataView<T> extends AbstractDataView<T> {
                     index, dataSize - 1));
         }
         return getItems().skip(index).findFirst().orElse(null);
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+        identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.radiobutton.dataview;
 
-import java.util.Optional;
-
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -76,7 +74,8 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.radiobutton.dataview;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -73,6 +75,7 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
     public void setIdentifierProvider(
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
-        identifierChangedCallback.accept(identifierProvider);
+        Optional.of(identifierChangedCallback)
+                .ifPresent(callback -> callback.accept(identifierProvider));
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -75,7 +75,8 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
     public void setIdentifierProvider(
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
-        Optional.of(identifierChangedCallback)
-                .ifPresent(callback -> callback.accept(identifierProvider));
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.radiobutton.dataview;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -29,6 +31,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * @since
  */
 public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Creates a new in-memory data view for RadioButtonGroup and verifies the
@@ -43,5 +47,32 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             RadioButtonGroup radioButtonGroup) {
         super(dataProviderSupplier, radioButtonGroup);
+    }
+
+    /**
+     * Creates a new in-memory data view for RadioButtonGroup and verifies the
+     * passed data provider is compatible with this data view implementation.
+     *
+     * @param dataProviderSupplier
+     *            data provider supplier
+     * @param radioButtonGroup
+     *            radioButton Group instance for this DataView
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public RadioButtonGroupListDataView(
+            SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
+            RadioButtonGroup radioButtonGroup,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup);
+        this.identifierChangedCallback = identifierChangedCallback;
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+        identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/CustomItem.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/CustomItem.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.radiobutton;
+
+import java.util.Objects;
+
+public class CustomItem {
+    private Long id;
+    private String name;
+
+    public CustomItem(Long id) {
+        this(id, null);
+    }
+
+    public CustomItem(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomItem)) return false;
+        CustomItem that = (CustomItem) o;
+        return Objects.equals(getName(), that.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/test/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTest.java
@@ -27,8 +27,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -50,9 +48,9 @@ public class RadioButtonGroupTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private class RadioButtunWithInitialValue extends
-            GeneratedVaadinRadioGroup<RadioButtunWithInitialValue, String> {
-        RadioButtunWithInitialValue() {
+    private class RadioButtonWithInitialValue extends
+            GeneratedVaadinRadioGroup<RadioButtonWithInitialValue, String> {
+        RadioButtonWithInitialValue() {
             super("", null, String.class, (group, value) -> value,
                     (group, value) -> value, true);
         }
@@ -249,10 +247,10 @@ public class RadioButtonGroupTest {
         Mockito.when(service.getInstantiator()).thenReturn(instantiator);
 
         Mockito.when(
-                instantiator.createComponent(RadioButtunWithInitialValue.class))
-                .thenAnswer(invocation -> new RadioButtunWithInitialValue());
-        RadioButtunWithInitialValue field = Component.from(element,
-                RadioButtunWithInitialValue.class);
+                instantiator.createComponent(RadioButtonWithInitialValue.class))
+                .thenAnswer(invocation -> new RadioButtonWithInitialValue());
+        RadioButtonWithInitialValue field = Component.from(element,
+                RadioButtonWithInitialValue.class);
         Assert.assertEquals("foo", field.getElement().getPropertyRaw("value"));
     }
 
@@ -275,5 +273,112 @@ public class RadioButtonGroupTest {
         radioButtonGroup.setItems(dataProvider);
 
         radioButtonGroup.getListDataView();
+    }
+
+    @Test
+    public void setIdentifierProvider_setItemWithIdentifierOnly_shouldSelectCorrectItem() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        RadioButtonGroup<CustomItem> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> listDataView =
+                radioButtonGroup.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        radioButtonGroup.setValue(new CustomItem(1L));
+
+        Assert.assertNotNull(radioButtonGroup.getValue());
+        Assert.assertEquals(radioButtonGroup.getValue().getName(), "First");
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item not with the reference of existing item, but instead
+        // with just the Id:
+        radioButtonGroup.setValue(new CustomItem(2L));
+
+        Assert.assertNotNull(radioButtonGroup.getValue());
+        Assert.assertEquals(Long.valueOf(2L), radioButtonGroup.getValue().getId());
+    }
+
+    @Test
+    public void setIdentifierProvider_setItemWithIdAndWrongName_shouldSelectCorrectItemBasedOnIdNotEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        RadioButtonGroup<CustomItem> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> listDataView =
+                radioButtonGroup.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        radioButtonGroup.setValue(new CustomItem(1L));
+
+        Assert.assertNotNull(radioButtonGroup.getValue());
+        Assert.assertEquals("First", radioButtonGroup.getValue().getName());
+
+        // Make the names similar to the name of not selected one to mess
+        // with the <equals> implementation in CustomItem:
+        first.setName("Second");
+        listDataView.refreshItem(first);
+        third.setName("Second");
+        listDataView.refreshItem(third);
+
+        // Select the item with an Id and the name that can be wrongly equals to
+        // another items, should verify that <equals> method is not in use:
+        radioButtonGroup.setValue(new CustomItem(3L, "Second"));
+
+        Assert.assertNotNull(radioButtonGroup.getValue());
+        Assert.assertEquals(Long.valueOf(3L), radioButtonGroup.getValue().getId());
+    }
+
+    @Test
+    public void withoutSettingIdentifierProvider_setItemWithNullId_shouldSelectCorrectItemBasedOnEquals() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        RadioButtonGroup<CustomItem> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> listDataView =
+                radioButtonGroup.setItems(items);
+
+        radioButtonGroup.setValue(new CustomItem(null, "Second"));
+
+        Assert.assertNotNull(radioButtonGroup.getValue());
+        Assert.assertEquals(Long.valueOf(2L), radioButtonGroup.getValue().getId());
+    }
+
+    @Test
+    public void setIdentifierProviderOnId_setItemWithNullId_shouldFailToSelectExistingItemById() {
+        CustomItem first = new CustomItem(1L, "First");
+        CustomItem second = new CustomItem(2L, "Second");
+        CustomItem third = new CustomItem(3L, "Third");
+        List<CustomItem> items = new ArrayList<>(Arrays.asList(first, second,
+                third));
+
+        RadioButtonGroup<CustomItem> radioButtonGroup = new RadioButtonGroup<>();
+        RadioButtonGroupListDataView<CustomItem> listDataView =
+                radioButtonGroup.setItems(items);
+        // Setting the following Identifier Provider makes the component
+        // independent from the CustomItem's equals method implementation:
+        listDataView.setIdentifierProvider(CustomItem::getId);
+
+        radioButtonGroup.setValue(new CustomItem(null, "First"));
+        Assert.assertNull(radioButtonGroup.getValue().getId());
     }
 }


### PR DESCRIPTION
Take `IdentifierProvider` into use use for determining the equality of the items in `vaadin-radio-button-flow`.
  
Fix: #273 