### PR TITLE
fix: override isLoading to return proper value (#241)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -35,6 +35,12 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
           }
         });
 
+        ItemCache.prototype.isLoading = tryCatchWrapper(function() {
+          return Boolean(ensureSubCacheQueue.length || Object.keys(this.pendingRequests).length || Object.keys(this.itemCaches).filter(index => {
+            return this.itemCaches[index].isLoading();
+          })[0]);
+        });
+
         ItemCache.prototype.doEnsureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
           if (!this.itemCaches[scaledIndex]) {
             const subCache = new ItemCache.prototype.constructor(this.grid, this, this.items[scaledIndex]);


### PR DESCRIPTION
Cherry-pick: #241

Web-component: grid

Fixes: vaadin/vaadin-grid#1809

Details: Flow Grid's connector overrides the ensureSubCacheForScaledIndex function, and adds a debouncer for the logic, the data request gets made asynchronously when expanding the Grids item. If the request for recalculateColumnWithds is done on expand listener, the width calculation might occasionally happen before the node gets expanded on the client-side, thus resulting into columns with undesired widths.