### PR TITLE
fix: override setValue to set proper value when detached (#275)

### DIFF
--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/frontend/src/detach-reattach.js
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/frontend/src/detach-reattach.js
@@ -1,0 +1,17 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import '@vaadin/vaadin-radio-button/src/vaadin-radio-group.js';
+
+class DetachReattach extends PolymerElement {
+    //language=html
+    static get template() {
+        return html`            
+            <vaadin-radio-group id="testGroup"></vaadin-radio-group>
+        `;
+    }
+
+    static get is() {
+        return 'detach-reattach';
+    }
+}
+
+customElements.define(DetachReattach.is, DetachReattach);

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom.xml
@@ -67,6 +67,12 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-radio-button-testbench</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
       <artifactId>flow-server-production-mode</artifactId>
       <version>${flow.version}</version>
     </dependency>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachPage.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Test view for {@link RadioButtonGroup}.
+ */
+@Route("vaadin-radio-button/detach-reattach")
+public class DetachReattachPage extends Div {
+    private final DetachReattachTemplate detachReattachTemplate;
+    private final Div valueBlock;
+    private String value;
+
+    public DetachReattachPage() {
+        this.detachReattachTemplate = new DetachReattachTemplate();
+        this.valueBlock = new Div();
+        valueBlock.setId("valueBlock");
+        add(valueBlock);
+
+        createGroupWithTemplate();
+        createGroup();
+    }
+
+    private void createGroupWithTemplate() {
+        NativeButton valueA = new NativeButton("Predefined value A", e -> value = "A");
+        NativeButton valueB = new NativeButton("Predefined value B", e -> value = "B");
+
+        valueA.setId("valueA");
+        valueB.setId("valueB");
+
+        NativeButton addGroup = new NativeButton("Add Group", e -> attachTemplate(value));
+        NativeButton removeGroup = new NativeButton("Remove Group", e -> remove(detachReattachTemplate));
+
+        addGroup.setId("addGroup");
+        removeGroup.setId("removeGroup");
+
+        NativeButton getValue = new NativeButton("Get Value Template", e ->
+                valueBlock.setText(detachReattachTemplate.getRBGValue()));
+        getValue.setId("getValueTemplate");
+
+        add(valueA, valueB, addGroup, removeGroup, getValue);
+    }
+
+    private void createGroup() {
+        RadioButtonGroup<String> group = new RadioButtonGroup<>();
+        group.setId("group");
+
+        List<String> items = new LinkedList<>(Arrays.asList("foo", "bar", "baz"));
+        group.setItems(new ListDataProvider<>(items));
+
+        NativeButton detach = new NativeButton("detach", e -> remove(group));
+        detach.setId("detach");
+
+        NativeButton attach = new NativeButton("attach", e -> add(group));
+        attach.setId("attach");
+
+        NativeButton setValue = new NativeButton("set value", e -> group.setValue("foo"));
+        setValue.setId("setValue");
+
+        NativeButton getValue = new NativeButton("Get Value", e ->
+                valueBlock.setText(group.getValue()));
+        getValue.setId("getValue");
+
+        add(group, detach, attach, setValue, getValue);
+    }
+
+    private void attachTemplate(String val) {
+        detachReattachTemplate.setRBGValue(val);
+        add(detachReattachTemplate);
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachPage.java
@@ -68,8 +68,7 @@ public class DetachReattachPage extends Div {
         RadioButtonGroup<String> group = new RadioButtonGroup<>();
         group.setId("group");
 
-        List<String> items = new LinkedList<>(Arrays.asList("foo", "bar", "baz"));
-        group.setItems(new ListDataProvider<>(items));
+        group.setItems("foo", "bar", "baz");
 
         NativeButton detach = new NativeButton("detach", e -> remove(group));
         detach.setId("detach");

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachTemplate.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachTemplate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@JsModule("./src/detach-reattach.js")
+@Tag("detach-reattach")
+public class DetachReattachTemplate extends PolymerTemplate<TemplateModel> {
+    @Id("testGroup")
+    RadioButtonGroup<String> testGroup;
+
+    public DetachReattachTemplate() {
+        testGroup.setItems("A", "B", "C");
+    }
+
+    public void setRBGValue(String val) {
+        testGroup.setValue(val);
+    }
+
+    public String getRBGValue() {
+        return testGroup.getValue();
+    }
+}
+

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/DetachReattachIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.radiobutton.tests;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("vaadin-radio-button/detach-reattach")
+public class DetachReattachIT extends AbstractComponentIT {
+    @Test
+    public void attachWithValue_detach_attachWithAnotherValue() {
+        open();
+        WebElement valueBlock = findElement(By.id("valueBlock"));
+
+        clickButton("valueA");
+        clickButton("addGroup");
+        clickButton("getValueTemplate");
+        Assert.assertEquals(valueBlock.getText(), "A");
+
+        clickButton("removeGroup");
+        clickButton("valueB");
+        clickButton("addGroup");
+        clickButton("getValueTemplate");
+        Assert.assertEquals(valueBlock.getText(), "B");
+    }
+
+    @Test
+    public void selectValue_detachRadioButtonGroup_reattach_valuesChecked() {
+        open();
+        WebElement valueBlock = findElement(By.id("valueBlock"));
+
+        clickButton("setValue");
+        clickButton("getValue");
+        String value = valueBlock.getText();
+
+        clickButton("detach");
+        clickButton("attach");
+        clickButton("getValue");
+        Assert.assertEquals("Radio button should remain checked on reattach",
+                value,
+                valueBlock.getText());
+    }
+
+    private void clickButton(String id) {
+        $("#" + id).first().click();
+    }
+}

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -125,6 +125,12 @@ public class RadioButtonGroup<T>
     }
 
     @Override
+    public void setValue(T value) {
+        super.setValue(value);
+        getRadioButtons().forEach(rb -> rb.setChecked(rb.getItem().equals(value)));
+    }
+
+    @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         if (getDataProvider() != null && dataProviderListenerRegistration == null) {


### PR DESCRIPTION
Cherry-pick: #275

Web-component: radio-button

Fixes: https://github.com/vaadin/vaadin-radio-button/issues/166

Details: RBG automatically adds RadioButtons inside of itself. If the RBG's value gets changed (setValue) while the component isn't in the DOM, the internal RB's remain unchanged. And once they're added back to DOM, Flow synchronizes the old RB values which causes the RBG to revert back to the old value. In order to fix it buttons will be reset on detach.

* Override setValue

* Add test for attach-detach