### PR TITLE
fix: Refresh KeyMapper on IdentifierProvider change

### DIFF
--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -153,7 +153,8 @@ public class CheckboxGroup<T>
      */
     @Override
     public CheckboxGroupListDataView<T> getListDataView() {
-        return new CheckboxGroupListDataView<>(this::getDataProvider, this);
+        return new CheckboxGroupListDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
     /**
@@ -166,7 +167,8 @@ public class CheckboxGroup<T>
      */
     @Override
     public CheckboxGroupDataView<T> getGenericDataView() {
-        return new CheckboxGroupDataView<>(this::getDataProvider, this);
+        return new CheckboxGroupDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
     private static class CheckBoxItem<T> extends Checkbox
@@ -606,5 +608,9 @@ public class CheckboxGroup<T>
         } else {
             return identifierProviderObject;
         }
+    }
+
+    private void identifierProviderChanged(IdentifierProvider<T> identifierProvider) {
+        keyMapper.setIdentifierGetter(identifierProvider);
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataView.java
@@ -18,7 +18,9 @@ package com.vaadin.flow.component.checkbox.dataview;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -29,6 +31,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * @since
  */
 public class CheckboxGroupDataView<T> extends AbstractDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Constructs a new DataView.
@@ -42,6 +46,25 @@ public class CheckboxGroupDataView<T> extends AbstractDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             CheckboxGroup<T> checkboxGroup) {
         super(dataProviderSupplier, checkboxGroup);
+    }
+
+    /**
+     * Constructs a new DataView.
+     *
+     * @param dataProviderSupplier
+     *            data provider supplier
+     * @param checkboxGroup
+     *            checkbox instance for this DataView
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public CheckboxGroupDataView(
+            SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
+            CheckboxGroup<T> checkboxGroup,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup);
+        this.identifierChangedCallback = identifierChangedCallback;
     }
 
     @Override
@@ -62,5 +85,14 @@ public class CheckboxGroupDataView<T> extends AbstractDataView<T> {
     @Override
     protected Class<?> getSupportedDataProviderType() {
         return DataProvider.class;
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupDataView.java
@@ -92,7 +92,8 @@ public class CheckboxGroupDataView<T> extends AbstractDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.checkbox.dataview;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -29,6 +31,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * @since
  */
 public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Creates a new in-memory data view for Checkbox Group and verifies the
@@ -43,5 +47,34 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             CheckboxGroup<T> checkboxGroup) {
         super(dataProviderSupplier, checkboxGroup);
+    }
+
+    /**
+     * Creates a new in-memory data view for Checkbox Group and verifies the
+     * passed data provider is compatible with this data view implementation.
+     *
+     * @param dataProviderSupplier
+     *            data provider supplier
+     * @param checkboxGroup
+     *            checkbox group instance for this DataView
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public CheckboxGroupListDataView(
+            SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
+            CheckboxGroup<T> checkboxGroup,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup);
+        this.identifierChangedCallback = identifierChangedCallback;
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
@@ -74,7 +74,8 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -507,7 +507,8 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
      */
     @Override
     public SelectDataView<T> getGenericDataView() {
-        return new SelectDataView<>(this::getDataProvider, this);
+        return new SelectDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
     /**
@@ -525,7 +526,8 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
      */
     @Override
     public SelectListDataView<T> getListDataView() {
-        return new SelectListDataView<>(this::getDataProvider, this);
+        return new SelectListDataView<>(this::getDataProvider, this,
+                this::identifierProviderChanged);
     }
 
     @Override
@@ -743,6 +745,30 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         initConnector();
     }
 
+    /**
+     * Compares two value instances to each other to determine whether they are
+     * equal. Equality is used to determine whether to update internal state and
+     * fire an event when {@link #setValue(Object)} or
+     * {@link #setModelValue(Object, boolean)} is called. Subclasses can
+     * override this method to define an alternative comparison method instead
+     * of {@link Objects#equals(Object)}.
+     *
+     * @param value1
+     *            the first instance
+     * @param value2
+     *            the second instance
+     * @return <code>true</code> if the instances are equal; otherwise
+     *         <code>false</code>
+     */
+    @Override
+    protected boolean valueEquals(T value1, T value2) {
+        if (value1 == null && value2 == null)
+            return true;
+        if (value1 == null || value2 == null)
+            return false;
+        return getItemId(value1).equals(getItemId(value2));
+    }
+
     private void initConnector() {
         runBeforeClientResponse(ui -> {
             ui.getPage().executeJs(
@@ -956,5 +982,13 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         } else {
             return identifierProviderObject;
         }
+    }
+
+    private Object getItemId(T item) {
+        return getIdentifierProvider().apply(item);
+    }
+
+    private void identifierProviderChanged(IdentifierProvider<T> identifierProvider) {
+        keyMapper.setIdentifierGetter(identifierProvider);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -762,10 +762,12 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
      */
     @Override
     protected boolean valueEquals(T value1, T value2) {
-        if (value1 == null && value2 == null)
+        if (value1 == null && value2 == null) {
             return true;
-        if (value1 == null || value2 == null)
+        }
+        if (value1 == null || value2 == null) {
             return false;
+        }
         return getItemId(value1).equals(getItemId(value2));
     }
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectDataView.java
@@ -19,7 +19,9 @@ package com.vaadin.flow.component.select.data;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.data.provider.AbstractDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -30,6 +32,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * @since
  */
 public class SelectDataView<T> extends AbstractDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Constructs a new DataView.
@@ -43,6 +47,25 @@ public class SelectDataView<T> extends AbstractDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             Select<T> select) {
         super(dataProviderSupplier, select);
+    }
+
+    /**
+     * Constructs a new DataView.
+     *
+     * @param dataProviderSupplier
+     *            data provider supplier
+     * @param select
+     *            select instance for this DataView
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public SelectDataView(
+            SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
+            Select<T> select,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, select);
+        this.identifierChangedCallback = identifierChangedCallback;
     }
 
     @Override
@@ -63,5 +86,14 @@ public class SelectDataView<T> extends AbstractDataView<T> {
     @Override
     protected Class<?> getSupportedDataProviderType() {
         return DataProvider.class;
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectDataView.java
@@ -93,7 +93,8 @@ public class SelectDataView<T> extends AbstractDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
@@ -58,7 +58,8 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
             IdentifierProvider<T> identifierProvider) {
         super.setIdentifierProvider(identifierProvider);
 
-        if (identifierChangedCallback != null)
+        if (identifierChangedCallback != null) {
             identifierChangedCallback.accept(identifierProvider);
+        }
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
@@ -3,6 +3,8 @@ package com.vaadin.flow.component.select.data;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -13,6 +15,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  *            item type
  */
 public class SelectListDataView<T> extends AbstractListDataView<T> {
+
+    private SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback;
 
     /**
      * Creates a new in-memory data view for Select and verifies the passed data
@@ -27,5 +31,34 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             Select<T> select) {
         super(dataProviderSupplier, select);
+    }
+
+    /**
+     * Creates a new in-memory data view for Select and verifies the passed data
+     * provider is compatible with this data view implementation.
+     *
+     * @param dataProviderSupplier
+     *            supplier from which the DataProvider can be gotten
+     * @param select
+     *            select component that the dataView is bound to
+     * @param identifierChangedCallback
+     *            callback method which should be called when identifierProvider
+     *            is changed
+     */
+    public SelectListDataView(
+            SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
+            Select<T> select,
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
+        super(dataProviderSupplier, select);
+        this.identifierChangedCallback = identifierChangedCallback;
+    }
+
+    @Override
+    public void setIdentifierProvider(
+            IdentifierProvider<T> identifierProvider) {
+        super.setIdentifierProvider(identifierProvider);
+
+        if (identifierChangedCallback != null)
+            identifierChangedCallback.accept(identifierProvider);
     }
 }


### PR DESCRIPTION
If applied, it will fix the KeyMapper mappings were not being refreshed after setting the IdentifierProvider through data-view API in CheckboxGroup and Select. 

Fixes: #308 