### PR TITLE
fix: Refactor usages of Arrays.asList to create ListDataView in ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -503,7 +503,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      */
     public ComboBoxListDataView<T> setItems(ItemFilter<T> itemFilter,
             @SuppressWarnings("unchecked") T... items) {
-        return setItems(itemFilter, Arrays.asList(items));
+        return setItems(itemFilter, new ArrayList<>(Arrays.asList(items)));
     }
 
     /**

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.combobox.dataview.ComboBoxListDataView;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
 import com.vaadin.flow.data.provider.DataCommunicator;
@@ -420,6 +421,18 @@ public class ComboBoxTest {
         fakeClientCommunication(ui);
 
         Mockito.verify(dataProvider).size(Mockito.any());
+    }
+
+    @Test
+    public void setItems_withItemFilterAndArrayOfItems_shouldReturnMutableListDataView() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        ComboBox.ItemFilter<String> itemFilter = (item, filter) -> true;
+        ComboBoxListDataView<String> listDataView = comboBox
+                .setItems(itemFilter, "First", "Second", "Third");
+        listDataView.addItem("Fourth");
+        listDataView.removeItem("First");
+        listDataView.removeItem("Third");
+        Assert.assertEquals(2L, listDataView.getItemCount());
     }
 
     private void assertItem(TestComboBox comboBox, int index, String caption) {


### PR DESCRIPTION
If applied, this update will enable users to obtain a fully functional `ComboBoxListDataView` by passing ItemFilter and an array of Items to the corresponding `setItem` method to be able to add/remove items through DataView API and not to encounter an `UnsupportedOperationException`. 

Fixes: #322  