### PR TITLE
fix: Ignore ComboBox client-side filter in data view items getters

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataView.java
@@ -73,10 +73,7 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
      */
     @Override
     public T getItem(int index) {
-        // TODO: change the implementation to make the returned item not depend
-        //  on client-side filter applied
-        //  https://github.com/vaadin/vaadin-flow-components/issues/282
-        return dataCommunicator.getItem(index);
+        return ItemFetchHelper.getItem(dataCommunicator, index);
     }
 
     @Override
@@ -95,8 +92,7 @@ public class ComboBoxDataView<T> extends AbstractDataView<T> {
      */
     @Override
     public Stream<T> getItems() {
-        return dataCommunicator.getDataProvider()
-                .fetch(dataCommunicator.buildQuery(0, Integer.MAX_VALUE));
+        return ItemFetchHelper.getItems(dataCommunicator);
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataView.java
@@ -142,10 +142,7 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
      */
     @Override
     public T getItem(int index) {
-        // TODO: change the implementation to make the returned item not depend
-        //  on client-side filter applied
-        //  https://github.com/vaadin/vaadin-flow-components/issues/282
-        return super.getItem(index);
+        return ItemFetchHelper.getItem(getDataCommunicator(), index);
     }
 
     /**
@@ -159,9 +156,6 @@ public class ComboBoxLazyDataView<T> extends AbstractLazyDataView<T> {
      */
     @Override
     public Stream<T> getItems() {
-        // TODO: change the implementation to make the returned item not depend
-        //  on client-side filter applied
-        //  https://github.com/vaadin/vaadin-flow-components/issues/282
-        return super.getItems();
+        return ItemFetchHelper.getItems(getDataCommunicator());
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.ItemCountChangeEvent;
-import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
 
@@ -70,7 +69,8 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
     @SuppressWarnings("unchecked")
     @Override
     public Stream<T> getItems() {
-        return getDataProvider().fetch(getQuery());
+        return getDataProvider()
+                .fetch(ItemFetchHelper.getQuery(dataCommunicator));
     }
 
     /**
@@ -89,7 +89,8 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
     @SuppressWarnings("unchecked")
     @Override
     public int getItemCount() {
-        return getDataProvider().size(getQuery());
+        return getDataProvider()
+                .size(ItemFetchHelper.getQuery(dataCommunicator));
     }
 
     @Override
@@ -117,10 +118,5 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
     public Registration addItemCountChangeListener(
             ComponentEventListener<ItemCountChangeEvent<?>> listener) {
         return super.addItemCountChangeListener(listener);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private Query getQuery() {
-        return dataCommunicator.buildQuery(0, Integer.MAX_VALUE);
     }
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ItemFetchHelper.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ItemFetchHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.combobox.dataview;
+
+import java.io.Serializable;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.data.provider.DataCommunicator;
+import com.vaadin.flow.data.provider.Query;
+
+/**
+ * Helper methods for fetching the ComboBox's items in data views.
+ */
+final class ItemFetchHelper implements Serializable {
+
+    private ItemFetchHelper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> Stream<T> getItems(DataCommunicator<T> dataCommunicator) {
+        return dataCommunicator.getDataProvider()
+                .fetch(getQuery(dataCommunicator));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T getItem(DataCommunicator<T> dataCommunicator, int index) {
+        if (index < 0) {
+            throw new IndexOutOfBoundsException("Index must be non-negative");
+        }
+        if (dataCommunicator.isDefinedSize()) {
+            final int itemCount = dataCommunicator.getDataProviderSize();
+            if (itemCount == 0) {
+                throw new IndexOutOfBoundsException(String
+                        .format("Requested index %d on empty data.", index));
+            } else if (index >= itemCount) {
+                throw new IndexOutOfBoundsException(String.format(
+                        "Given index %d is outside of the accepted range '0 - %d'",
+                        index, itemCount - 1));
+            }
+        }
+        return (T) dataCommunicator.getDataProvider()
+                .fetch(getQuery(dataCommunicator, index, 1)).findFirst()
+                .orElse(null);
+    }
+
+    @SuppressWarnings("rawtypes")
+    static <T> Query getQuery(DataCommunicator<T> dataCommunicator) {
+        return getQuery(dataCommunicator, 0, Integer.MAX_VALUE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    static <T> Query getQuery(DataCommunicator<T> dataCommunicator, int offset,
+            int limit) {
+        return dataCommunicator.buildQuery(offset, limit);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ItemFetchHelper.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ItemFetchHelper.java
@@ -30,12 +30,37 @@ final class ItemFetchHelper implements Serializable {
     private ItemFetchHelper() {
     }
 
+    /**
+     * Gets the items available in the ComboBox's service-side by requesting the
+     * data provider directly, and not using the data communicator's cache.
+     * 
+     * @param dataCommunicator
+     *            data communicator of the ComboBox
+     * @param <T>
+     *            item type
+     * @return stream of items available for the ComboBox
+     */
     @SuppressWarnings("unchecked")
     static <T> Stream<T> getItems(DataCommunicator<T> dataCommunicator) {
         return dataCommunicator.getDataProvider()
                 .fetch(getQuery(dataCommunicator));
     }
 
+    /**
+     * Gets the item at the given index from the data available in the
+     * ComboBox's server-side by requesting the data provider directly, and not
+     * using the data communicator's cache.
+     * 
+     * @param dataCommunicator
+     *            data communicator of the ComboBox
+     * @param index
+     *            item index number
+     * @param <T>
+     *            item type
+     * @return item on index
+     * @throws IndexOutOfBoundsException
+     *             requested index is outside of the data set
+     */
     @SuppressWarnings("unchecked")
     static <T> T getItem(DataCommunicator<T> dataCommunicator, int index) {
         if (index < 0) {
@@ -48,8 +73,8 @@ final class ItemFetchHelper implements Serializable {
                         .format("Requested index %d on empty data.", index));
             } else if (index >= itemCount) {
                 throw new IndexOutOfBoundsException(String.format(
-                        "Given index %d is outside of the accepted range '0 - %d'",
-                        index, itemCount - 1));
+                        "Given index %d should be less than the item count '%d'",
+                        index, itemCount));
             }
         }
         return (T) dataCommunicator.getDataProvider()
@@ -57,11 +82,37 @@ final class ItemFetchHelper implements Serializable {
                 .orElse(null);
     }
 
+    /**
+     * Creates a query to be used by data provider for fetching a whole range of
+     * items taking into account the filtering and sorting of a given data
+     * communicator.
+     * 
+     * @param dataCommunicator
+     *            data communicator of the ComboBox
+     * @param <T>
+     *            item type
+     * @return query object
+     */
     @SuppressWarnings("rawtypes")
     static <T> Query getQuery(DataCommunicator<T> dataCommunicator) {
         return getQuery(dataCommunicator, 0, Integer.MAX_VALUE);
     }
 
+    /**
+     * Creates a query to be used by data provider for fetching a given range of
+     * items taking into account the filtering and sorting of a given data
+     * communicator.
+     * 
+     * @param dataCommunicator
+     *            data communicator of the ComboBox
+     * @param offset
+     *            offset for data request
+     * @param limit
+     *            number of items to fetch
+     * @param <T>
+     *            item type
+     * @return query object
+     */
     @SuppressWarnings("rawtypes")
     static <T> Query getQuery(DataCommunicator<T> dataCommunicator, int offset,
             int limit) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -326,7 +326,7 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
     public void getItem_outsideOfRange_throws() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage(
-                "Given index 3 is outside of the accepted range '0 - 2'");
+                "Given index 3 should be less than the item count '3'");
         dataView.getItem(3);
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.combobox.dataview;
+
+import java.lang.reflect.Method;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+
+final class ComboBoxDataViewTestHelper {
+
+    private ComboBoxDataViewTestHelper() {
+    }
+
+    static void setClientSideFilter(ComboBox<String> comboBox,
+                                 String clientFilter) {
+        try {
+            // Reset the client filter on server side as though it's sent from
+            // client
+            Method setRequestedRangeMethod = ComboBox.class.getDeclaredMethod(
+                    "setRequestedRange", int.class, int.class, String.class);
+            setRequestedRangeMethod.setAccessible(true);
+            setRequestedRangeMethod.invoke(comboBox, 0, comboBox.getPageSize(),
+                    clientFilter);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void fakeClientCommunication(DataCommunicatorTest.MockUI ui) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -385,7 +385,7 @@ public class ComboBoxLazyDataViewTest {
     public void getItem_definedItemCountAndOutsideOfRange_throws() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage(
-                "Given index 3 is outside of the accepted range '0 - 2'");
+                "Given index 3 should be less than the item count '3'");
         dataView.getItem(3);
     }
 
@@ -402,7 +402,7 @@ public class ComboBoxLazyDataViewTest {
     public void getItem_withCountCallbackAndOutsideOfRange_throw() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage(
-                "Given index 1234567 is outside of the accepted range '0 - 999'");
+                "Given index 1234567 should be less than the item count '1000'");
         dataCommunicator.setDataProvider(undefinedItemCountDataProvider, "",
                 true);
         dataView.setItemCountCallback(query -> 1000);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -16,11 +16,9 @@
 
 package com.vaadin.flow.component.combobox.dataview;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -63,8 +61,8 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         items = Arrays.asList("foo", "bar", "banana");
         dataView = component.setItems(items);
 
-        setClientFilter(component, "ba");
-        fakeClientCommunication();
+        ComboBoxDataViewTestHelper.setClientSideFilter(component, "ba");
+        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
 
         Stream<String> filteredItems = dataView.getItems();
 
@@ -97,8 +95,8 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         items = Arrays.asList("foo", "bar", "banana");
         dataView = component.setItems(items);
 
-        setClientFilter(component, "ba");
-        fakeClientCommunication();
+        ComboBoxDataViewTestHelper.setClientSideFilter(component, "ba");
+        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
 
         int itemCount = dataView.getItemCount();
 
@@ -146,36 +144,6 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
     @Override
     protected HasListDataView<String, ComboBoxListDataView<String>> getComponent() {
         return new ComboBox<>();
-    }
-
-    private ComboBox<String> getDefaultLocaleComboBox() {
-        return new ComboBox<String>() {
-            @Override
-            protected Locale getLocale() {
-                return Locale.getDefault();
-            }
-        };
-    }
-
-    private void setClientFilter(ComboBox<String> comboBox,
-            String clientFilter) {
-        try {
-            // Reset the client filter on server side as though it's sent from
-            // client
-            Method setRequestedRangeMethod = ComboBox.class.getDeclaredMethod(
-                    "setRequestedRange", int.class, int.class, String.class);
-            setRequestedRangeMethod.setAccessible(true);
-            setRequestedRangeMethod.invoke(comboBox, 0, comboBox.getPageSize(),
-                    clientFilter);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void fakeClientCommunication() {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        ui.getInternals().getStateTree().collectChanges(ignore -> {
-        });
     }
 
     private static class Item {


### PR DESCRIPTION
ComboBox's data views getItem() and getItems() methods implementations modified in a way to be not affected by client-side filter.

Fixes: https://github.com/vaadin/vaadin-flow-components/issues/282