### PR TITLE
test: add ITs to verify reattach - refresh page should keep expansion

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachPage.java
@@ -19,9 +19,11 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.bean.HierarchicalTestBean;
+import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid/treegrid-detach-attach")
+@PreserveOnRefresh
 public class TreeGridDetachAttachPage extends Div {
 
     private TreeGrid<HierarchicalTestBean> grid;

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetachAttachIT.java
@@ -48,4 +48,28 @@ public class TreeGridDetachAttachIT extends AbstractComponentIT {
         Assert.assertEquals("0 | 0", grid.getCell(0, 0).getText());
     }
 
+    @Test
+    public void reattachTreeGrid_expandRow_shouldMaintainExpansionAfterReattach() {
+        Assert.assertFalse(grid.isRowExpanded(2, 0));
+        grid.expandWithClick(2);
+        Assert.assertTrue(grid.isRowExpanded(2, 0));
+
+        toggleAttachedButton.click();
+        toggleAttachedButton.click();
+
+        grid = $(TreeGridElement.class).first();
+        Assert.assertTrue(grid.isRowExpanded(2, 0));
+    }
+
+    @Test
+    public void refreshViewWithPreserveOnRefresh_expandRow_shouldMaintainExpansionAfterRefreshPage() {
+        Assert.assertFalse(grid.isRowExpanded(2, 0));
+        grid.expandWithClick(2);
+        Assert.assertTrue(grid.isRowExpanded(2, 0));
+
+        getDriver().navigate().refresh();
+
+        grid = $(TreeGridElement.class).first();
+        Assert.assertTrue(grid.isRowExpanded(2, 0));
+    }
 }


### PR DESCRIPTION
Added Integration Tests to verify that `TreeGrid` keeps the expanded nodes state after being reattached or after the page is refreshed with a view annotated with `@PreserveOnRefresh`. These ITs added as complement to the changes made in https://github.com/vaadin/flow/pull/9275 .
 
Related-to: https://github.com/vaadin/flow/issues/9175