### PR TITLE
fix: Store in-memory filtering and sorting in component

### DIFF
--- a/scripts/updateNpmVer.js
+++ b/scripts/updateNpmVer.js
@@ -2,8 +2,10 @@
 /**
  * Update the NpmPackage annotation for all modules in the project
  * by checking versions published in npm repository.
+ * By using `--exclude <component>,<component>`, the certain package update will be skipped
  * Example
- *   ./scripts/updateNpmVer.js vaadin-button-flow-parent
+ *   ./scripts/updateNpmVer.js
+ *   ./scripts/updateNpmVer.js --exclude button,text-field
  */
 
 const fs = require('fs');
@@ -67,13 +69,41 @@ async function calculateVersions(data) {
   return data;
 }
 
+/**
+ * Allow exclude certain component package update, use ',' as separator
+ */
+async function excludeComponents() {
+  for (i = 2;process.argv[i]; i++) {
+    switch(process.argv[i]) {
+      case '--exclude':
+        components = process.argv[++i]
+        break;
+      }
+  }
+  
+  component=components.split(',');
+  
+  packageBase='@vaadin/vaadin-';
+  for(j = 0; j < component.length; j++){
+	  component[j] = packageBase.concat(component[j]);
+  }
+  
+  return component;
+}
+
 async function main() {
   console.log("Updating the NpmPackage annotation.")
   const modules = await computeModules();
+  const excluded = await excludeComponents();
 
   for (i = 0; i < modules.length; i++){
-    modules[i] = await calculateVersions(modules[i]);
-    await updateFiles(modules[i]);
+	if (excluded.includes(modules[i].package)){
+		console.log('\x1b[33m',"skip updating "+ modules[i].package +" package");
+	} else {
+		modules[i] = await calculateVersions(modules[i]);
+        await updateFiles(modules[i]);
+	}
+    
   }
 }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupListDataViewPage.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/main/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupListDataViewPage.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.checkbox.tests;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -25,12 +23,15 @@ import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.checkbox.dataview.CheckboxGroupListDataView;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-checkbox-group-list-data-view")
 public class CheckboxGroupListDataViewPage extends Div {
 
     static final String CHECKBOX_GROUP = "checkbox-group-data-view";
+    static final String OTHER_CHECKBOX_GROUP = "other-checkbox-group-data-view";
     static final String ITEMS_SIZE = "size-span-data-view";
     static final String ITEM_PRESENT = "item-present-span-data-view";
     static final String ALL_ITEMS = "all-items-span-data-view";
@@ -49,16 +50,23 @@ public class CheckboxGroupListDataViewPage extends Div {
     public CheckboxGroupListDataViewPage() {
         CheckboxGroup<CheckboxGroupDemoPage.Person> checkboxGroup =
                 new CheckboxGroup<>();
+        CheckboxGroup<CheckboxGroupDemoPage.Person> otherCheckBox = new CheckboxGroup<>();
+
         CheckboxGroupDemoPage.Person john =
                 new CheckboxGroupDemoPage.Person(1, "John");
         CheckboxGroupDemoPage.Person paul =
                 new CheckboxGroupDemoPage.Person(2, "Paul");
         CheckboxGroupDemoPage.Person mike =
                 new CheckboxGroupDemoPage.Person(3, "Mike");
+
+        final ListDataProvider<CheckboxGroupDemoPage.Person> personListDataProvider = DataProvider
+                .ofItems(john, paul, mike);
+
         CheckboxGroupListDataView<CheckboxGroupDemoPage.Person> dataView =
-                checkboxGroup.setItems(new ArrayList<>(Arrays.asList(
-                        john, paul, mike)
-                ));
+                checkboxGroup.setItems(personListDataProvider);
+
+        otherCheckBox.setItems(personListDataProvider);
+
         Span sizeSpan = new Span(String.valueOf(dataView.getItemCount()));
         Span containsItemSpan = new Span(String.valueOf(
                 dataView.contains(john)));
@@ -104,15 +112,16 @@ public class CheckboxGroupListDataViewPage extends Div {
         Button updateName = new Button("Update first name",
                 event -> {
                     CheckboxGroupDemoPage.Person updatedPerson =
-                            dataView.getItem(3);
+                            dataView.getItem(0);
                     updatedPerson.setName("Jack");
                     dataView.refreshItem(updatedPerson);
                 });
         Button deletePerson = new Button("Delete person",
                 event -> dataView.removeItem(
-                        new CheckboxGroupDemoPage.Person(4, null)));
+                        new CheckboxGroupDemoPage.Person(1, null)));
 
         checkboxGroup.setId(CHECKBOX_GROUP);
+        otherCheckBox.setId(OTHER_CHECKBOX_GROUP);
         sizeSpan.setId(ITEMS_SIZE);
         containsItemSpan.setId(ITEM_PRESENT);
         allItemsSpan.setId(ALL_ITEMS);
@@ -131,6 +140,6 @@ public class CheckboxGroupListDataViewPage extends Div {
         add(checkboxGroup, sizeSpan, containsItemSpan, allItemsSpan,
                 itemOnIndexSpan, currentItemSpan, hasNextItemSpan,
                 hasPrevItemSpan, filterButton, sortButton, nextItemButton,
-                prevItemButton, addNew, updateName, deletePerson);
+                prevItemButton, addNew, updateName, deletePerson, otherCheckBox);
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupListDataViewIT.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupListDataViewIT.java
@@ -18,39 +18,51 @@ package com.vaadin.flow.component.checkbox.tests;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 @TestPath("vaadin-checkbox-group-list-data-view")
 public class CheckboxGroupListDataViewIT extends AbstractComponentIT {
 
-    @Test
-    public void checkboxGroupListDataView_dataViewApiRequested_dataAvailable() {
+    private TestBenchElement checkboxGroup;
+    private TestBenchElement otherCheckboxGroup;
+
+    @Before
+    public void init() {
         open();
 
-        TestBenchElement checkboxGroup = $("vaadin-checkbox-group")
+        checkboxGroup = $("vaadin-checkbox-group")
                 .id(CheckboxGroupListDataViewPage.CHECKBOX_GROUP);
 
-        List<TestBenchElement> checkboxes =
-                checkboxGroup.$("vaadin-checkbox").all();
+        otherCheckboxGroup = $("vaadin-checkbox-group")
+                .id(CheckboxGroupListDataViewPage.OTHER_CHECKBOX_GROUP);
+    }
+
+    @Test
+    public void getItems_showsCheckboxContent() {
+        List<TestBenchElement> checkboxes = checkboxGroup.$("vaadin-checkbox")
+                .all();
 
         // Checkbox items size
         Assert.assertEquals("Unexpected checkbox count", 3, checkboxes.size());
 
         // Data set size
-        Assert.assertEquals("Unexpected item count", "3",
-                $("span").id(CheckboxGroupListDataViewPage.ITEMS_SIZE)
-                        .getText());
+        Assert.assertEquals("Unexpected item count", "3", $("span")
+                .id(CheckboxGroupListDataViewPage.ITEMS_SIZE).getText());
 
         // Data set content
         Assert.assertEquals("Unexpected checkbox labels", "John,Paul,Mike",
                 $("span").id(CheckboxGroupListDataViewPage.ALL_ITEMS)
                         .getText());
+    }
 
+    @Test
+    public void navigateBetweenItems_showCorrectItems() {
         // Item present
         Assert.assertEquals("Person 'John' is expected to be present", "true",
                 $("span").id(CheckboxGroupListDataViewPage.ITEM_PRESENT)
@@ -62,60 +74,108 @@ public class CheckboxGroupListDataViewIT extends AbstractComponentIT {
                         .getText());
 
         // Has next item
-        Assert.assertEquals("Next item is expected", "true",
-                $("span").id(CheckboxGroupListDataViewPage.HAS_NEXT_ITEM)
-                        .getText());
+        Assert.assertEquals("Next item is expected", "true", $("span")
+                .id(CheckboxGroupListDataViewPage.HAS_NEXT_ITEM).getText());
 
         // Has previous item
-        Assert.assertEquals("Previous item is expected", "true",
-                $("span").id(CheckboxGroupListDataViewPage.HAS_PREVIOUS_ITEM)
-                        .getText());
+        Assert.assertEquals("Previous item is expected", "true", $("span")
+                .id(CheckboxGroupListDataViewPage.HAS_PREVIOUS_ITEM).getText());
 
         findElement(By.id(CheckboxGroupListDataViewPage.NEXT_ITEM)).click();
 
         // Next item
-        Assert.assertEquals("Unexpected next item", "Mike",
-                $("span").id(CheckboxGroupListDataViewPage.CURRENT_ITEM)
-                        .getText());
+        Assert.assertEquals("Unexpected next item", "Mike", $("span")
+                .id(CheckboxGroupListDataViewPage.CURRENT_ITEM).getText());
 
         findElement(By.id(CheckboxGroupListDataViewPage.PREVIOUS_ITEM)).click();
 
         // Previous item
-        Assert.assertEquals("Unexpected previous item", "Paul",
-                $("span").id(CheckboxGroupListDataViewPage.CURRENT_ITEM)
-                        .getText());
+        Assert.assertEquals("Unexpected previous item", "Paul", $("span")
+                .id(CheckboxGroupListDataViewPage.CURRENT_ITEM).getText());
+    }
 
-        // Add item
+    @Test
+    public void addItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(CheckboxGroupListDataViewPage.ADD_ITEM)).click();
-        Assert.assertEquals("Wrong name for added person",
+
+        Assert.assertEquals(
+                "Unexpected item count after adding a new item in first "
+                        + "CheckboxGroup",
+                4, checkboxGroup.$("vaadin-checkbox").all().size());
+
+        Assert.assertEquals(
+                "Wrong name for added person in first CheckboxGroup", "Peter",
+                checkboxGroup.$("vaadin-checkbox").all().get(3).getText());
+
+        Assert.assertEquals(
+                "Unexpected item count after adding a new item in"
+                        + " second CheckboxGroup",
+                4, checkboxGroup.$("vaadin-checkbox").all().size());
+
+        Assert.assertEquals(
+                "Wrong name for added person in second " + "CheckboxGroup",
                 "Peter",
-                checkboxGroup.$("vaadin-checkbox").all().get(3).getText());
+                otherCheckboxGroup.$("vaadin-checkbox").all().get(3).getText());
+    }
 
-        // Update item
+    @Test
+    public void updateItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(CheckboxGroupListDataViewPage.UPDATE_ITEM)).click();
-        Assert.assertEquals("Wrong name for updated person",
-                "Jack",
-                checkboxGroup.$("vaadin-checkbox").all().get(3).getText());
 
-        // Delete item
+        Assert.assertEquals("Wrong name for updated person in first Checkbox",
+                "Jack",
+                checkboxGroup.$("vaadin-checkbox").all().get(0).getText());
+
+        Assert.assertEquals("Wrong name for updated person in second Checkbox",
+                "Jack",
+                otherCheckboxGroup.$("vaadin-checkbox").all().get(0).getText());
+    }
+
+    @Test
+    public void deleteItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(CheckboxGroupListDataViewPage.DELETE_ITEM)).click();
-        Assert.assertEquals("Item count not expected", 3,
+
+        Assert.assertEquals("Unexpected item count in first Checkbox", 2,
                 checkboxGroup.$("vaadin-checkbox").all().size());
 
-        // Sort order
+        Assert.assertEquals("Unexpected item count in second Checkbox", 2,
+                otherCheckboxGroup.$("vaadin-checkbox").all().size());
+    }
+
+    @Test
+    public void sorting_itemsSortedOnlyInOneComponent() {
         findElement(By.id(CheckboxGroupListDataViewPage.SORT_BUTTON)).click();
+
         Assert.assertEquals("Unexpected sort order", "John,Mike,Paul",
                 checkboxGroup.$("vaadin-checkbox").all().stream()
                         .map(TestBenchElement::getText)
                         .collect(Collectors.joining(",")));
 
+        Assert.assertEquals("Unexpected sort order", "John,Paul,Mike",
+                otherCheckboxGroup.$("vaadin-checkbox").all().stream()
+                        .map(TestBenchElement::getText)
+                        .collect(Collectors.joining(",")));
+    }
+
+    @Test
+    public void filtering_itemsFilteredOnlyInOneComponent() {
         findElement(By.id(CheckboxGroupListDataViewPage.FILTER_BUTTON)).click();
 
-        // Filtering
-        checkboxes = checkboxGroup.$("vaadin-checkbox").all();
+        List<TestBenchElement> checkboxes = checkboxGroup.$("vaadin-checkbox")
+                .all();
         Assert.assertEquals("Unexpected filtered checkbox count", 1,
                 checkboxes.size());
         Assert.assertEquals("Unexpected filtered checkbox item", "Paul",
                 checkboxes.get(0).getText());
+
+        // Verify no impact on other component bound to the same data provider
+        checkboxes = otherCheckboxGroup.$("vaadin-checkbox").all();
+        Assert.assertEquals("No filter expected on other CheckboxGroup bound "
+                + "to the same data provider", 3, checkboxes.size());
+        Assert.assertArrayEquals(
+                "No filtering expected on other "
+                        + "CheckboxGroup bound to the same data provider",
+                new String[] { "John", "Paul", "Mike" },
+                checkboxes.stream().map(TestBenchElement::getText).toArray());
     }
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.IdentifierProvider;
@@ -53,11 +54,8 @@ import com.vaadin.flow.data.selection.MultiSelectionEvent;
 import com.vaadin.flow.data.selection.MultiSelectionListener;
 import com.vaadin.flow.dom.PropertyChangeEvent;
 import com.vaadin.flow.dom.PropertyChangeListener;
-import com.vaadin.flow.function.SerializableBiConsumer;
-import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -624,83 +622,13 @@ public class CheckboxGroup<T>
     @SuppressWarnings("rawtypes")
     private Query getQuery() {
         return new Query<>(0, Integer.MAX_VALUE, null,
-                InnerCheckboxGroupListDataView.getComponentSortComparator(this)
-                        .orElse(null),
-                InnerCheckboxGroupListDataView.getComponentFilter(this)
-                        .orElse(null));
+                DataViewUtils.getComponentSortComparator(this).orElse(null),
+                DataViewUtils.getComponentFilter(this).orElse(null));
     }
 
     private void removeFilteringAndSorting() {
-        InnerCheckboxGroupListDataView.removeComponentFilter(this);
-        InnerCheckboxGroupListDataView.removeComponentSortComparator(this);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static final class InnerCheckboxGroupListDataView
-            extends CheckboxGroupListDataView {
-
-        private InnerCheckboxGroupListDataView(
-                SerializableSupplier dataProviderSupplier,
-                CheckboxGroup checkboxGroup,
-                SerializableBiConsumer dataChangedCallback) {
-            super(dataProviderSupplier, checkboxGroup, dataChangedCallback);
-        }
-
-        /**
-         * Gets the in-memory filter of a given CheckboxGroup instance.
-         *
-         * @param checkboxGroup
-         *            CheckboxGroup instance the filter is bound to
-         * @param <T>
-         *            item type
-         * @return optional CheckboxGroup's in-memory filter.
-         */
-        static <T> Optional<SerializablePredicate<T>> getComponentFilter(
-                CheckboxGroup<T> checkboxGroup) {
-            return CheckboxGroupListDataView.getComponentFilter(checkboxGroup);
-        }
-
-        /**
-         * Gets the in-memory sort comparator of a given CheckboxGroup instance.
-         *
-         * @param checkboxGroup
-         *            CheckboxGroup instance the sort comparator is bound to
-         * @param <T>
-         *            item type
-         * @return optional CheckboxGroup's in-memory sort comparator.
-         */
-        static <T> Optional<SerializableComparator<T>> getComponentSortComparator(
-                CheckboxGroup<T> checkboxGroup) {
-            return CheckboxGroupListDataView
-                    .getComponentSortComparator(checkboxGroup);
-        }
-
-        /**
-         * Removes the in-memory filter from a given CheckboxGroup instance.
-         *
-         * @param checkboxGroup
-         *            CheckboxGroup instance the filter is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentFilter(CheckboxGroup<T> checkboxGroup) {
-            CheckboxGroupListDataView.setComponentFilter(checkboxGroup, null);
-        }
-
-        /**
-         * Removes the in-memory sort comparator from a given CheckboxGroup
-         * instance.
-         *
-         * @param checkboxGroup
-         *            CheckboxGroup instance the sort comparator is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentSortComparator(
-                CheckboxGroup<T> checkboxGroup) {
-            CheckboxGroupListDataView.setComponentSortComparator(checkboxGroup,
-                    null);
-        }
+        DataViewUtils.removeComponentFilter(this);
+        DataViewUtils.removeComponentSortComparator(this);
     }
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -210,7 +210,7 @@ public class CheckboxGroup<T>
     @Deprecated
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
-        removeFilteringAndSorting();
+        DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
 
         if (dataProviderListenerRegistration != null) {
@@ -465,7 +465,7 @@ public class CheckboxGroup<T>
         synchronized (dataProvider) {
             final AtomicInteger itemCounter = new AtomicInteger(0);
 
-            getDataProvider().fetch(getQuery())
+            getDataProvider().fetch(DataViewUtils.getQuery(this))
                     .map(item -> createCheckBox((T) item))
                     .forEach(component -> {
                         add((Component) component);
@@ -617,18 +617,6 @@ public class CheckboxGroup<T>
 
     private void identifierProviderChanged(IdentifierProvider<T> identifierProvider) {
         keyMapper.setIdentifierGetter(identifierProvider);
-    }
-
-    @SuppressWarnings("rawtypes")
-    private Query getQuery() {
-        return new Query<>(0, Integer.MAX_VALUE, null,
-                DataViewUtils.getComponentSortComparator(this).orElse(null),
-                DataViewUtils.getComponentFilter(this).orElse(null));
-    }
-
-    private void removeFilteringAndSorting() {
-        DataViewUtils.removeComponentFilter(this);
-        DataViewUtils.removeComponentSortComparator(this);
     }
 
 }

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
@@ -19,7 +19,10 @@ import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -42,11 +45,15 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param checkboxGroup
      *            checkbox group instance for this DataView
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the CheckboxGroup's
+     *            filtering or sorting changes, not <code>null</code>
      */
     public CheckboxGroupListDataView(
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
-            CheckboxGroup<T> checkboxGroup) {
-        super(dataProviderSupplier, checkboxGroup);
+            CheckboxGroup<T> checkboxGroup,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup, dataChangedCallback);
     }
 
     /**
@@ -60,12 +67,16 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the CheckboxGroup's
+     *            filtering or sorting changes, not <code>null</code>
      */
     public CheckboxGroupListDataView(
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             CheckboxGroup<T> checkboxGroup,
-            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
-        super(dataProviderSupplier, checkboxGroup);
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup, dataChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/dataview/CheckboxGroupListDataView.java
@@ -45,15 +45,15 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param checkboxGroup
      *            checkbox group instance for this DataView
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the CheckboxGroup's
      *            filtering or sorting changes, not <code>null</code>
      */
     public CheckboxGroupListDataView(
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             CheckboxGroup<T> checkboxGroup,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, checkboxGroup, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup, filterOrSortingChangedCallback);
     }
 
     /**
@@ -67,7 +67,7 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the CheckboxGroup's
      *            filtering or sorting changes, not <code>null</code>
      */
@@ -75,8 +75,8 @@ public class CheckboxGroupListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             CheckboxGroup<T> checkboxGroup,
             SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, checkboxGroup, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, checkboxGroup, filterOrSortingChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
@@ -27,12 +27,16 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.router.Route;
 
 @Route("combobox-list-data-view-page")
 public class ComboBoxListDataViewPage extends Div {
 
+    public static final String FIRST_COMBO_BOX_ID = "first-combo-box";
+    public static final String SECOND_COMBO_BOX_ID = "second-combo-box";
     public static final String ITEM_COUNT = "itemCount";
     public static final String ITEM_DATA = "itemData";
     public static final String ITEM_SELECT = "itemSelect";
@@ -45,12 +49,21 @@ public class ComboBoxListDataViewPage extends Div {
 
     public ComboBoxListDataViewPage() {
         List<Person> personList = generatePersonItems();
+        final ListDataProvider<Person> dataProvider = DataProvider
+                .ofCollection(personList);
+
         ComboBox<Person> comboBox = new ComboBox<>();
         comboBox.setAllowCustomValue(true);
         comboBox.setItemLabelGenerator(Person::getFirstName);
+        comboBox.setId(FIRST_COMBO_BOX_ID);
+
+        ComboBox<Person> secondComboBox = new ComboBox<>();
+        secondComboBox.setId(SECOND_COMBO_BOX_ID);
 
         final ComboBoxListDataView<Person> dataView = comboBox
-                .setItems(personList);
+                .setItems(dataProvider);
+
+        secondComboBox.setItems(dataProvider);
 
         // Add custom item to collection
         comboBox.addCustomValueSetListener(event -> {
@@ -145,7 +158,7 @@ public class ComboBoxListDataViewPage extends Div {
 
         add(comboBox, itemSelect, filterByAge, reverseSorting,
                 selectItemOnIndex, showItemData, showNextData, showPreviousData,
-                removePerson, count, itemData);
+                removePerson, count, itemData, secondComboBox);
     }
 
     private List<Person> generatePersonItems() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -593,19 +593,19 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         // null filter
         DataProvider<T, String> convertedDataProvider =
                 new DataProviderWrapper<T, String, SerializablePredicate<T>>(
-                inMemoryDataProvider) {
-            @Override
-            protected SerializablePredicate<T> getFilter(
-                    Query<T, String> query) {
-                        final Optional<SerializablePredicate<?>> componentInMemoryFilter = DataViewUtils
+                        inMemoryDataProvider) {
+                    @Override
+                    protected SerializablePredicate<T> getFilter(
+                            Query<T, String> query) {
+                        final Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
                                 .getComponentFilter(comboBox);
                         return Optional
                                 .ofNullable(inMemoryDataProvider.getFilter())
-                        .orElse(item -> true)
-                        .and(item -> filterConverter
-                                .apply(query.getFilter().orElse(""))
+                                .orElse(item -> true)
+                                .and(item -> filterConverter
+                                        .apply(query.getFilter().orElse(""))
                                         .test(item))
-                                .and((SerializablePredicate<T>) componentInMemoryFilter
+                                .and(componentInMemoryFilter
                                         .orElse(item -> true));
             }
         };
@@ -1054,11 +1054,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         setDataProvider(listDataProvider,
                 filterText -> {
-                    Optional<SerializablePredicate<?>> componentInMemoryFilter = DataViewUtils
+                    Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
                             .getComponentFilter(this);
                     return item -> itemFilter.test(item, filterText)
-                            && ((SerializablePredicate<T>) componentInMemoryFilter
-                                    .orElse(ignore -> true))
+                            && componentInMemoryFilter.orElse(ignore -> true)
                                     .test(item);
                 });
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
 import com.vaadin.flow.data.provider.DataView;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasLazyDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
@@ -596,7 +597,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             @Override
             protected SerializablePredicate<T> getFilter(
                     Query<T, String> query) {
-                        final Optional<SerializablePredicate<T>> componentInMemoryFilter = InnerComboBoxListDataView
+                        final Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
                                 .getComponentFilter(comboBox);
                         return Optional
                                 .ofNullable(inMemoryDataProvider.getFilter())
@@ -1053,7 +1054,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         setDataProvider(listDataProvider,
                 filterText -> {
-                    Optional<SerializablePredicate<T>> componentInMemoryFilter = InnerComboBoxListDataView
+                    Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
                             .getComponentFilter(this);
                     return item -> itemFilter.test(item, filterText)
                             && componentInMemoryFilter.orElse(ignore -> true)
@@ -1591,29 +1592,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         lastFilter = null;
         filterSlot.accept("");
         reset();
-    }
-
-    private static final class InnerComboBoxListDataView
-            extends ComboBoxListDataView {
-
-        private InnerComboBoxListDataView(DataCommunicator dataCommunicator,
-                ComboBox comboBox, SerializableBiConsumer dataChangedCallback) {
-            super(dataCommunicator, comboBox, dataChangedCallback);
-        }
-
-        /**
-         * Returns an in-memory filter of a given ComboBox instance.
-         *
-         * @param comboBox
-         *            ComboBox instance the filter bound to
-         * @param <T>
-         *            item type
-         * @return optional ComboBox's in-memory filter.
-         */
-        static <T> Optional<SerializablePredicate<T>> getComponentFilter(
-                ComboBox<T> comboBox) {
-            return ComboBoxListDataView.getComponentFilter(comboBox);
-        }
     }
 
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -60,7 +60,6 @@ import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.Rendering;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.PropertyChangeEvent;
-import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableBiPredicate;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -691,7 +690,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     @Override
     public ComboBoxListDataView<T> getListDataView() {
         return new ComboBoxListDataView<T>(dataCommunicator, this,
-                this::onDataChange);
+                this::onInMemoryFilterOrSortingChange);
     }
 
     /**
@@ -1584,7 +1583,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         }
     }
 
-    private void onDataChange(SerializablePredicate<T> filter,
+    private void onInMemoryFilterOrSortingChange(
+            SerializablePredicate<T> filter,
             SerializableComparator<T> sortComparator) {
         dataCommunicator.setInMemorySorting(sortComparator);
         // Erase the current filter to ensure the execution of

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -597,7 +597,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             @Override
             protected SerializablePredicate<T> getFilter(
                     Query<T, String> query) {
-                        final Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
+                        final Optional<SerializablePredicate<?>> componentInMemoryFilter = DataViewUtils
                                 .getComponentFilter(comboBox);
                         return Optional
                                 .ofNullable(inMemoryDataProvider.getFilter())
@@ -605,7 +605,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                         .and(item -> filterConverter
                                 .apply(query.getFilter().orElse(""))
                                         .test(item))
-                                .and(componentInMemoryFilter
+                                .and((SerializablePredicate<T>) componentInMemoryFilter
                                         .orElse(item -> true));
             }
         };
@@ -1054,10 +1054,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         setDataProvider(listDataProvider,
                 filterText -> {
-                    Optional<SerializablePredicate<T>> componentInMemoryFilter = DataViewUtils
+                    Optional<SerializablePredicate<?>> componentInMemoryFilter = DataViewUtils
                             .getComponentFilter(this);
                     return item -> itemFilter.test(item, filterText)
-                            && componentInMemoryFilter.orElse(ignore -> true)
+                            && ((SerializablePredicate<T>) componentInMemoryFilter
+                                    .orElse(ignore -> true))
                                     .test(item);
                 });
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -18,12 +18,14 @@ package com.vaadin.flow.component.combobox.dataview;
 
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.IdentifierProvider;
 import com.vaadin.flow.data.provider.ItemCountChangeEvent;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.shared.Registration;
 
@@ -46,10 +48,14 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
      *            the data communicator of the ComboBox, not <code>null</code>
      * @param comboBox
      *            the ComboBox component, not <code>null</code>
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the ComboBox's filtering
+     *            or sorting changes, not <code>null</code>
      */
     public ComboBoxListDataView(DataCommunicator<T> dataCommunicator,
-            ComboBox<T> comboBox) {
-        super(dataCommunicator::getDataProvider, comboBox);
+            ComboBox<T> comboBox,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataCommunicator::getDataProvider, comboBox, dataChangedCallback);
         this.dataCommunicator = dataCommunicator;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataView.java
@@ -48,14 +48,14 @@ public class ComboBoxListDataView<T> extends AbstractListDataView<T> {
      *            the data communicator of the ComboBox, not <code>null</code>
      * @param comboBox
      *            the ComboBox component, not <code>null</code>
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the ComboBox's filtering
      *            or sorting changes, not <code>null</code>
      */
     public ComboBoxListDataView(DataCommunicator<T> dataCommunicator,
             ComboBox<T> comboBox,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataCommunicator::getDataProvider, comboBox, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataCommunicator::getDataProvider, comboBox, filterOrSortingChangedCallback);
         this.dataCommunicator = dataCommunicator;
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTest.java
@@ -136,7 +136,8 @@ public class ComboBoxDataViewTest extends AbstractComponentDataViewTest {
         // In-memory combo box data view
         dataCommunicator.setDataProvider(DataProvider.ofCollection(items),
                 null);
-        dataView = new ComboBoxListDataView<>(dataCommunicator, comboBox);
+        dataView = new ComboBoxListDataView<>(dataCommunicator, comboBox,
+                (filter, sorting) -> {});
         // We need to repopulate the keyMapper after setting a new data provider
         items.forEach(keyMapper::key);
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxDataViewTestHelper.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.component.combobox.dataview;
 
 import java.lang.reflect.Method;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.combobox.ComboBox;
-import com.vaadin.flow.data.provider.DataCommunicatorTest;
 
 final class ComboBoxDataViewTestHelper {
 
@@ -41,7 +41,7 @@ final class ComboBoxDataViewTestHelper {
         }
     }
 
-    static void fakeClientCommunication(DataCommunicatorTest.MockUI ui) {
+    static void fakeClientCommunication(UI ui) {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {
         });

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -132,7 +132,7 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
                 }, null, null, component.getElement().getNode());
 
         ComboBoxListDataView<Item> dataView = new ComboBoxListDataView<>(
-                dataCommunicator, component);
+                dataCommunicator, component, (filter, sorting) -> {});
         DataKeyMapper<Item> keyMapper = dataCommunicator.getKeyMapper();
         items.forEach(keyMapper::key);
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridListDataViewPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridListDataViewPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -29,6 +30,9 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.bean.Address;
 import com.vaadin.flow.data.bean.Gender;
 import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
@@ -47,18 +51,36 @@ public class GridListDataViewPage extends Div {
     public static final String ADD_ITEM = "addItem";
     public static final String UPDATE_ITEM = "updateItem";
     public static final String DELETE_ITEM = "deleteItem";
+    public static final String FIRST_GRID_ID = "first-grid";
+    public static final String SECOND_GRID_ID = "second-grid";
+    public static final String ADD_EXTRA_PERSONS_FOR_SORTING = "add-extra-persons";
+    public static final String ADD_SERVER_SIDE_SORTING = "add-server-side-sorting";
+    public static final String REMOVE_SERVER_SIDE_SORTING = "remove-server-side-sorting";
 
     public GridListDataViewPage() {
         List<Person> personList = generatePersonItems();
+        final ListDataProvider<Person> dataProvider = DataProvider
+                .ofCollection(personList);
+
         Grid<Person> grid = new Grid<>(Person.class);
+        grid.setId(FIRST_GRID_ID);
+
+        Grid<Person> secondGrid = new Grid<>(Person.class);
+        secondGrid.setId(SECOND_GRID_ID);
+
         final GridListDataView<Person> dataView = grid
-                .setItems(personList);
+                .setItems(dataProvider);
+
+        secondGrid.setItems(dataProvider);
 
         grid.removeColumnByKey("id");
+        secondGrid.removeColumnByKey("id");
 
         // The Grid<>(Person.class) sorts the properties and in order to
         // reorder the properties we use the 'setColumns' method.
         grid.setColumns("firstName", "lastName", "age");
+        secondGrid.setColumns("firstName", "lastName", "age");
+
         Span count = new Span(Integer.toString(dataView.getItemCount()));
         count.setId(ITEM_COUNT);
         Span itemData = new Span("Item: ");
@@ -114,6 +136,23 @@ public class GridListDataViewPage extends Div {
                     dataView.removeItem(deletedPerson);
                 });
         deletePerson.setId(DELETE_ITEM);
+        Button addExtraPersons = new Button("Add extra Persons", event -> {
+            Person person18 = new Person("Person 99", "lastName",
+                    "person99@test.com", 18, Gender.UNKNOWN, new Address());
+            Person person42 = new Person("Person 99", "lastName",
+                    "person99@test.com", 42, Gender.UNKNOWN, new Address());
+
+            dataView.addItems(Arrays.asList(person18, person42));
+        });
+        addExtraPersons.setId(ADD_EXTRA_PERSONS_FOR_SORTING);
+
+        Button addSorting = new Button("Add sorting by Age", event -> dataView
+                .setSortOrder(Person::getAge, SortDirection.DESCENDING));
+        addSorting.setId(ADD_SERVER_SIDE_SORTING);
+
+        Button removeSorting = new Button("Remove sorting by Age",
+                event -> dataView.removeSorting());
+        removeSorting.setId(REMOVE_SERVER_SIDE_SORTING);
 
         dataView.addItemCountChangeListener(event -> {
             count.setText(Integer.toString(event.getItemCount()));
@@ -138,7 +177,8 @@ public class GridListDataViewPage extends Div {
 
         add(grid, rowSelect, filterByFirstName, selectItemOnRow, showItemData,
                 showNextData, showPreviousData, count, itemData,
-                addNewPerson, updateFirstNameField, deletePerson);
+                addNewPerson, updateFirstNameField, deletePerson,
+                addExtraPersons, addSorting, removeSorting, secondGrid);
     }
 
     private List<Person> generatePersonItems() {

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridListDataViewIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridListDataViewIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.grid.it;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
@@ -25,12 +26,17 @@ import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
+import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ADD_EXTRA_PERSONS_FOR_SORTING;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ADD_ITEM;
+import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ADD_SERVER_SIDE_SORTING;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.DELETE_ITEM;
+import static com.vaadin.flow.component.grid.it.GridListDataViewPage.FIRST_GRID_ID;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.FIRST_NAME_FILTER;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ITEM_COUNT;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ITEM_DATA;
+import static com.vaadin.flow.component.grid.it.GridListDataViewPage.REMOVE_SERVER_SIDE_SORTING;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.ROW_SELECT;
+import static com.vaadin.flow.component.grid.it.GridListDataViewPage.SECOND_GRID_ID;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.SHOW_ITEM_DATA;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.SHOW_NEXT_DATA;
 import static com.vaadin.flow.component.grid.it.GridListDataViewPage.SHOW_PREVIOUS_DATA;
@@ -39,14 +45,25 @@ import static com.vaadin.flow.component.grid.it.GridListDataViewPage.UPDATE_ITEM
 @TestPath("vaadin-grid/grid-list-data-view-page")
 public class GridListDataViewIT extends AbstractComponentIT {
 
-    @Test
-    public void gridDataViewReturnsExpectedData() {
-        open();
-        GridElement grid = $(GridElement.class).first();
+    private GridElement firstGrid;
+    private GridElement secondGrid;
 
+    @Before
+    public void init() {
+        open();
+
+        firstGrid = $(GridElement.class).id(FIRST_GRID_ID);
+        secondGrid = $(GridElement.class).id(SECOND_GRID_ID);
+    }
+
+    @Test
+    public void getItemCount_showsInitialItemsCount() {
         Assert.assertEquals("Item count not expected", "250",
                 $("span").id(ITEM_COUNT).getText());
+    }
 
+    @Test
+    public void navigateBetweenItems_showsCorrectItems() {
         Assert.assertEquals("Initial selection should be 0", "0",
                 $(IntegerFieldElement.class).id(ROW_SELECT).getValue());
 
@@ -77,52 +94,184 @@ public class GridListDataViewIT extends AbstractComponentIT {
         $(ButtonElement.class).id(SHOW_PREVIOUS_DATA).click();
         Assert.assertEquals("Wrong previous item.", "Item: Person 5",
                 $("span").id(ITEM_DATA).getText());
+    }
 
+    @Test
+    public void sorting_setClientThenServerSorting_bothSortingsApplied() {
         // Sort highest first. NOTE! this means that we start with 99
-        grid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
-        grid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+        applyClientSortByFirstName();
+
+        // Set the second row (from top) as the current item
+        $(IntegerFieldElement.class).id(ROW_SELECT).setValue("1");
 
         $(ButtonElement.class).id(SHOW_ITEM_DATA).click();
-        Assert.assertEquals("Wrong row item for sorted data", "Item: Person 94",
+        Assert.assertEquals("Wrong row item for sorted data", "Item: Person 98",
                 $("span").id(ITEM_DATA).getText());
 
         $(ButtonElement.class).id(SHOW_NEXT_DATA).click();
-        Assert.assertEquals("Wrong next item for sorted data.", "Item: Person 93",
+        Assert.assertEquals("Wrong next item for sorted data.",
+                "Item: Person 97",
                 $("span").id(ITEM_DATA).getText());
 
         $(ButtonElement.class).id(SHOW_PREVIOUS_DATA).click();
-        Assert.assertEquals("Wrong previous item for sorted data.", "Item: Person 95",
+        Assert.assertEquals("Wrong previous item for sorted data.",
+                "Item: Person 99",
                 $("span").id(ITEM_DATA).getText());
 
+        $(ButtonElement.class).id(ADD_EXTRA_PERSONS_FOR_SORTING).click();
+
+        $(ButtonElement.class).id(ADD_SERVER_SIDE_SORTING).click();
+
+        Assert.assertEquals("Unexpected first name on row 0", "Person 99",
+                getFirstNameByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected first name on row 1", "Person 99",
+                getFirstNameByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected first name on row 2", "Person 99",
+                getFirstNameByRow(firstGrid, 2));
+
+        Assert.assertEquals("Unexpected age on row 0", "42",
+                getAgeByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected age on row 1", "24",
+                getAgeByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected age on row 2", "18",
+                getAgeByRow(firstGrid, 2));
+
+        $(ButtonElement.class).id(REMOVE_SERVER_SIDE_SORTING).click();
+
+        Assert.assertEquals("Unexpected first name on row 0", "Person 99",
+                getFirstNameByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected first name on row 1", "Person 99",
+                getFirstNameByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected first name on row 2", "Person 99",
+                getFirstNameByRow(firstGrid, 2));
+
+        Assert.assertEquals("Unexpected age on row 0", "24",
+                getAgeByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected age on row 1", "18",
+                getAgeByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected age on row 2", "42",
+                getAgeByRow(firstGrid, 2));
+    }
+
+    @Test
+    public void sorting_setServerThenClientSorting_bothSortingsApplied() {
+        $(ButtonElement.class).id(ADD_EXTRA_PERSONS_FOR_SORTING).click();
+        $(ButtonElement.class).id(ADD_SERVER_SIDE_SORTING).click();
+
+        // Person 89
+        Assert.assertEquals("Unexpected age on row 0", "104",
+                getAgeByRow(firstGrid, 0));
+        // Person 179
+        Assert.assertEquals("Unexpected age on row 1", "104",
+                getAgeByRow(firstGrid, 1));
+        // Person 88
+        Assert.assertEquals("Unexpected age on row 2", "103",
+                getAgeByRow(firstGrid, 2));
+        // Person 178
+        Assert.assertEquals("Unexpected age on row 3", "103",
+                getAgeByRow(firstGrid, 3));
+
+        // Sort highest first. NOTE! this means that we start with 99
+        // Client sort should have higher priority
+        applyClientSortByFirstName();
+
+        Assert.assertEquals("Unexpected first name on row 0", "Person 99",
+                getFirstNameByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected first name on row 1", "Person 99",
+                getFirstNameByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected first name on row 2", "Person 99",
+                getFirstNameByRow(firstGrid, 2));
+
+        Assert.assertEquals("Unexpected age on row 0", "42",
+                getAgeByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected age on row 1", "24",
+                getAgeByRow(firstGrid, 1));
+        Assert.assertEquals("Unexpected age on row 2", "18",
+                getAgeByRow(firstGrid, 2));
+    }
+
+    @Test
+    public void sorting_setSortingToFirstGrid_secondGridNotImpacted() {
+        $(ButtonElement.class).id(ADD_SERVER_SIDE_SORTING).click();
+
+        Assert.assertEquals("Unexpected first name on row 0 in first grid",
+                "Person 89", getFirstNameByRow(firstGrid, 0));
+        Assert.assertEquals("Unexpected age on row 0 in first grid", "104",
+                getAgeByRow(firstGrid, 0));
+
+        Assert.assertEquals("Unexpected first name on row 0 in second grid",
+                "Person 1", getFirstNameByRow(secondGrid, 0));
+        Assert.assertEquals("Unexpected age on row 0 in second grid", "16",
+                getAgeByRow(secondGrid, 0));
+    }
+
+
+    @Test
+    public void addRemoveAndUpdateItem_addsThenUpdatesThenRemovesItem() {
         $(ButtonElement.class).id(ADD_ITEM).click();
         Assert.assertEquals("Item count not expected", "251",
                 $("span").id(ITEM_COUNT).getText());
         Assert.assertEquals("Wrong first name for added person",
-                "John", grid.getCell(250, 0).getText());
+                "John", firstGrid.getCell(250, 0).getText());
         Assert.assertEquals("Wrong last name for added person",
-                "Doe", grid.getCell(250, 1).getText());
+                "Doe", firstGrid.getCell(250, 1).getText());
         Assert.assertEquals("Wrong age for added person",
-                "33", grid.getCell(250, 2).getText());
+                "33", firstGrid.getCell(250, 2).getText());
 
         $(IntegerFieldElement.class).id(ROW_SELECT).setValue("250");
         $(TextFieldElement.class).id(UPDATE_ITEM).setValue("Bob");
         Assert.assertEquals("Wrong first name for updated person",
-                "Bob", grid.getCell(250, 0).getText());
+                "Bob", firstGrid.getCell(250, 0).getText());
         Assert.assertEquals("Wrong last name for updated person",
-                "Doe", grid.getCell(250, 1).getText());
+                "Doe", firstGrid.getCell(250, 1).getText());
         Assert.assertEquals("Wrong age for updated person",
-                "33", grid.getCell(250, 2).getText());
+                "33", firstGrid.getCell(250, 2).getText());
 
         $(IntegerFieldElement.class).id(ROW_SELECT).setValue("250");
         $(ButtonElement.class).id(DELETE_ITEM).click();
         Assert.assertEquals("Item count not expected", "250",
                 $("span").id(ITEM_COUNT).getText());
+    }
 
+    @Test
+    public void setFilter_serverSideFilterAppliedToFirstGridAndNotForSecond() {
         $(TextFieldElement.class).id(FIRST_NAME_FILTER).setValue("9");
 
         // There are 43 firstnames with a 9 in the set from 1-250
         Assert.assertEquals("Filtered size not as expected", "43",
                 $("span").id(ITEM_COUNT).getText());
+
+        // Verify the first grid contains filtered set of items
+        Assert.assertEquals(43, firstGrid.getRowCount());
+
+        // Verify the second grid contains non-filtered set of items
+        Assert.assertEquals(250, secondGrid.getRowCount());
+
+        // Reset the filter
+        $(TextFieldElement.class).id(FIRST_NAME_FILTER).setValue("");
+
+        // Verify that both grids have 250 items
+        Assert.assertEquals("Filtered size not as expected", "250",
+                $("span").id(ITEM_COUNT).getText());
+
+        Assert.assertEquals(250, firstGrid.getRowCount());
+
+        Assert.assertEquals(250, secondGrid.getRowCount());
+    }
+
+    private void applyClientSortByFirstName() {
+        firstGrid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+        firstGrid.getHeaderCell(0).$("vaadin-grid-sorter").first().click();
+    }
+
+    private String getFirstNameByRow(GridElement grid, int row) {
+        return grid.getRow(row).getCell(grid.getColumn("First Name"))
+                .getText();
+    }
+
+    private String getAgeByRow(GridElement grid, int row) {
+        return grid.getRow(row).getCell(grid.getColumn("Age"))
+                .getText();
     }
 
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1167,6 +1167,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
     private final List<GridSortOrder<T>> sortOrder = new ArrayList<>();
 
+    // This callback is only used by GridListDataView when the data filtering
+    // is being changed through its API
     private SerializableConsumer<?> filterSlot;
 
     private Class<T> beanType;
@@ -3216,7 +3218,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
 
         sortOrder.clear();
         if (order.isEmpty()) {
-            // Grid is not sorted anymore with client-side sorting.
+            // Grid's sorting is being reset by Grid's sort API or by clicking
+            // on a Grid's sortable column header, but the sorting, which was
+            // set through the GridListDataView API, is being preserved.
             getDataCommunicator().setBackEndSorting(Collections.emptyList());
             getDataCommunicator().setInMemorySorting(
                     (SerializableComparator<T>) DataViewUtils

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -85,6 +85,7 @@ import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderListener;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
 import com.vaadin.flow.data.provider.DataView;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataGenerators;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasLazyDataView;
@@ -3217,8 +3218,9 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
         if (order.isEmpty()) {
             // Grid is not sorted anymore with client-side sorting.
             getDataCommunicator().setBackEndSorting(Collections.emptyList());
-            getDataCommunicator().setInMemorySorting(InnerGridListDataView
-                    .getComponentSortComparator(this).orElse(null));
+            getDataCommunicator().setInMemorySorting(
+                    (SerializableComparator<T>) DataViewUtils
+                            .getComponentSortComparator(this).orElse(null));
             fireEvent(new SortEvent<>(this, new ArrayList<>(sortOrder),
                     userOriginated));
             return;
@@ -3269,8 +3271,8 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
     private void sort(boolean userOriginated) {
         // Set sort orders
         // In-memory comparator
-        updateSorting(InnerGridListDataView.getComponentSortComparator(this)
-                .orElse(null));
+        updateSorting((SerializableComparator<T>) DataViewUtils
+                .getComponentSortComparator(this).orElse(null));
 
         // Back-end sort properties
         List<QuerySortOrder> sortProperties = new ArrayList<>();
@@ -4153,27 +4155,5 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
             }
             return result;
         };
-    }
-
-    private static final class InnerGridListDataView extends GridListDataView {
-
-        private InnerGridListDataView(DataCommunicator dataCommunicator,
-                Grid grid, SerializableBiConsumer dataChangedCallback) {
-            super(dataCommunicator, grid, dataChangedCallback);
-        }
-
-        /**
-         * Returns an in-memory sort comparator of a given Grid instance.
-         *
-         * @param grid
-         *            Grid instance the filter bound to
-         * @param <T>
-         *            item type
-         * @return optional Grid's in-memory sort comparator.
-         */
-        static <T> Optional<SerializableComparator<T>> getComponentSortComparator(
-                Grid<T> grid) {
-            return GridListDataView.getComponentSortComparator(grid);
-        }
     }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridListDataView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridListDataView.java
@@ -44,14 +44,14 @@ public class GridListDataView<T> extends AbstractListDataView<T> {
      *            the data communicator of the Grid, not <code>null</code>
      * @param grid
      *            the Grid component, not <code>null</code>
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the Grid's filtering or
      *            sorting changes, not <code>null</code>
      */
     public GridListDataView(DataCommunicator<T> dataCommunicator,
             Grid<T> grid,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataCommunicator::getDataProvider, grid, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataCommunicator::getDataProvider, grid, filterOrSortingChangedCallback);
         this.dataCommunicator = dataCommunicator;
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridListDataView.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/dataview/GridListDataView.java
@@ -21,6 +21,9 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializablePredicate;
 
 /**
  * Data view implementation for Grid with in-memory list data. Provides
@@ -33,9 +36,22 @@ import com.vaadin.flow.data.provider.IdentifierProvider;
 public class GridListDataView<T> extends AbstractListDataView<T> {
     private DataCommunicator<T> dataCommunicator;
 
+    /**
+     * Creates a new instance of Grid in-memory data view and verifies the
+     * passed data provider is compatible with this data view implementation.
+     *
+     * @param dataCommunicator
+     *            the data communicator of the Grid, not <code>null</code>
+     * @param grid
+     *            the Grid component, not <code>null</code>
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the Grid's filtering or
+     *            sorting changes, not <code>null</code>
+     */
     public GridListDataView(DataCommunicator<T> dataCommunicator,
-                            Grid<T> grid) {
-        super(dataCommunicator::getDataProvider, grid);
+            Grid<T> grid,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataCommunicator::getDataProvider, grid, dataChangedCallback);
         this.dataCommunicator = dataCommunicator;
     }
 

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewPage.java
@@ -34,6 +34,8 @@ import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.listbox.dataview.ListBoxDataView;
 import com.vaadin.flow.component.listbox.dataview.ListBoxListDataView;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
 
@@ -53,6 +55,11 @@ public class ListBoxDataViewPage extends Div {
     static final String LIST_BOX_FOR_FILTER_DATA_VIEW = "list-box-for-filter-data-view";
     static final String LIST_BOX_FOR_NEXT_PREV_DATA_VIEW = "list-box-for-next-prev-data-view";
     static final String LIST_BOX_FOR_SORT_DATA_VIEW = "list-box-for-sort-data-view";
+
+    static final String OTHER_LIST_BOX_FOR_ADD_TO_DATA_VIEW = "other-list-box-for-add-to-data-view";
+    static final String OTHER_LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW = "other-list-box-for-remove-from-data-view";
+    static final String OTHER_LIST_BOX_FOR_FILTER_DATA_VIEW = "other-list-box-for-filter-data-view";
+    static final String OTHER_LIST_BOX_FOR_SORT_DATA_VIEW = "other-list-box-for-sort-data-view";
 
     static final String DATA_VIEW_UPDATE_BUTTON = "data-view-update-button";
     static final String LIST_DATA_VIEW_UPDATE_BUTTON = "list-data-view-update-button";
@@ -139,14 +146,20 @@ public class ListBoxDataViewPage extends Div {
 
     private void createAddItemByDataView() {
         Item first = new Item(1L, FIRST);
-        List<Item> items = new ArrayList<>();
-        items.add(first);
 
         ListBox<Item> listBoxForAddToDataView = new ListBox<>();
         listBoxForAddToDataView.setId(LIST_BOX_FOR_ADD_TO_DATA_VIEW);
 
+        ListBox<Item> otherListBox = new ListBox<>();
+        otherListBox.setId(OTHER_LIST_BOX_FOR_ADD_TO_DATA_VIEW);
+
+        final ListDataProvider<Item> listDataProvider = DataProvider
+                .ofItems(first);
+
         ListBoxListDataView<Item> dataView = listBoxForAddToDataView
-                .setItems(items);
+                .setItems(listDataProvider);
+
+        otherListBox.setItems(listDataProvider);
 
         NativeButton dataViewAddButton = new NativeButton("Add", click -> {
             Item second = new Item(2L, SECOND);
@@ -154,32 +167,48 @@ public class ListBoxDataViewPage extends Div {
         });
         dataViewAddButton.setId(LIST_DATA_VIEW_ADD_BUTTON);
 
-        add(listBoxForAddToDataView, dataViewAddButton);
+        add(listBoxForAddToDataView, otherListBox, dataViewAddButton);
     }
 
     private void createRemoveItemByDataView() {
         Item first = new Item(1L, FIRST);
         Item second = new Item(2L, SECOND);
-        List<Item> items = new ArrayList<>(Arrays.asList(first, second));
 
         ListBox<Item> listBoxForRemoveFromDataView = new ListBox<>();
         listBoxForRemoveFromDataView.setId(LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW);
 
+        ListBox<Item> otherListBox = new ListBox<>();
+        otherListBox.setId(OTHER_LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW);
+
+        final ListDataProvider<Item> listDataProvider = DataProvider
+                .ofItems(first, second);
+
         ListBoxListDataView<Item> dataView = listBoxForRemoveFromDataView
-                .setItems(items);
+                .setItems(listDataProvider);
+
+        otherListBox.setItems(listDataProvider);
 
         NativeButton dataViewRemoveButton = new NativeButton("Remove",
                 click -> dataView.removeItem(second));
         dataViewRemoveButton.setId(LIST_DATA_VIEW_REMOVE_BUTTON);
 
-        add(listBoxForRemoveFromDataView, dataViewRemoveButton);
+        add(listBoxForRemoveFromDataView, otherListBox, dataViewRemoveButton);
     }
 
     private void createFilterItemsByDataView() {
         ListBox<Integer> numbers = new ListBox<>();
         numbers.setId(LIST_BOX_FOR_FILTER_DATA_VIEW);
+
+        ListBox<Integer> otherNumbers = new ListBox<>();
+        otherNumbers.setId(OTHER_LIST_BOX_FOR_FILTER_DATA_VIEW);
+
+        final ListDataProvider<Integer> dataProvider = DataProvider.ofItems(1,
+                2, 3, 4, 5, 6, 7, 8, 9, 10);
+
         ListBoxListDataView<Integer> numbersDataView = numbers
-                .setItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .setItems(dataProvider);
+
+        otherNumbers.setItems(dataProvider);
 
         NativeButton filterOdds = new NativeButton("Filter Odds",
                 click -> numbersDataView.setFilter(num -> num % 2 == 0));
@@ -194,7 +223,8 @@ public class ListBoxDataViewPage extends Div {
                 click -> numbersDataView.removeFilters());
         noFilter.setId(LIST_DATA_VIEW_REMOVE_FILTER_BUTTON);
 
-        add(numbers, filterOdds, filterMultiplesOfThree, noFilter);
+        add(numbers, otherNumbers, filterOdds, filterMultiplesOfThree,
+                noFilter);
     }
 
     private void createNextPreviousItemDataView() {
@@ -248,20 +278,27 @@ public class ListBoxDataViewPage extends Div {
         Item first = new Item(1L, FIRST);
         Item second = new Item(2L, SECOND);
         Item third = new Item(3L, THIRD);
-        List<Item> items = new ArrayList<>(Arrays.asList(third, first, second));
 
         ListBox<Item> listBoxForSortDataView = new ListBox<>();
         listBoxForSortDataView.setId(LIST_BOX_FOR_SORT_DATA_VIEW);
 
+        ListBox<Item> otherListBox = new ListBox<>();
+        otherListBox.setId(OTHER_LIST_BOX_FOR_SORT_DATA_VIEW);
+
+        final ListDataProvider<Item> dataProvider = DataProvider.ofItems(third,
+                first, second);
+
         ListBoxListDataView<Item> dataView = listBoxForSortDataView
-                .setItems(items);
+                .setItems(dataProvider);
+
+        otherListBox.setItems(dataProvider);
 
         NativeButton dataViewSortButton = new NativeButton("Sort",
                 click -> dataView.setSortComparator((item1, item2) -> item1
                         .getValue().compareToIgnoreCase(item2.getValue())));
         dataViewSortButton.setId(LIST_DATA_VIEW_SORT_BUTTON);
 
-        add(listBoxForSortDataView, dataViewSortButton);
+        add(listBoxForSortDataView, otherListBox, dataViewSortButton);
     }
 
     private void createIdentifierProviderForMultiSelectListBox() {

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/listbox/test/ListBoxDataViewIT.java
@@ -18,14 +18,13 @@ package com.vaadin.flow.component.listbox.test;
 
 import java.util.List;
 
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-
-import com.vaadin.tests.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
 
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.CURRENT_ITEM_SPAN;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.DATA_VIEW_UPDATE_BUTTON;
@@ -49,9 +48,13 @@ import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DA
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SET_FILTER_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_SORT_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.LIST_DATA_VIEW_UPDATE_BUTTON;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTION_BY_ID_AND_NAME_BUTTON;
 import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTION_UPDATE_BUTTON;
-import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.MULTI_SELECT_LIST_BOX_SELECTED_IDS_SPAN;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.OTHER_LIST_BOX_FOR_ADD_TO_DATA_VIEW;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.OTHER_LIST_BOX_FOR_FILTER_DATA_VIEW;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.OTHER_LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW;
+import static com.vaadin.flow.component.listbox.test.ListBoxDataViewPage.OTHER_LIST_BOX_FOR_SORT_DATA_VIEW;
 
 @TestPath("vaadin-list-box/list-box-data-view")
 public class ListBoxDataViewIT extends AbstractComponentIT {
@@ -127,6 +130,11 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
 
         Assert.assertEquals("Second RadioButton should have the text", SECOND,
                 items.get(1).getText());
+
+        listBox = findElement(By.id(OTHER_LIST_BOX_FOR_ADD_TO_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
+
+        Assert.assertEquals("ListBox should have items", 2, items.size());
     }
 
     @Test
@@ -150,6 +158,12 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
 
         Assert.assertEquals("First RadioButton should have the text", FIRST,
                 items.get(0).getText());
+
+        listBox = findElement(By.id(OTHER_LIST_BOX_FOR_REMOVE_FROM_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
+
+        Assert.assertEquals("Unexpected item count after removing one item "
+                + "for second radio button group", 1, items.size());
     }
 
     @Test
@@ -176,6 +190,13 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
         items = listBox.findElements(By.tagName(VAADIN_ITEM));
 
         Assert.assertEquals("ListBox should have items", 4, items.size());
+
+        listBox = findElement(By.id(OTHER_LIST_BOX_FOR_FILTER_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
+
+        Assert.assertEquals(
+                "Unexpected filtering for second radion button group", 10,
+                items.size());
 
         findElement(By.id(LIST_DATA_VIEW_REMOVE_FILTER_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_ITEM));
@@ -252,6 +273,14 @@ public class ListBoxDataViewIT extends AbstractComponentIT {
                 "second", items.get(1).getText());
         Assert.assertEquals("third rendered item's text should be",
                 "third", items.get(2).getText());
+
+        listBox = findElement(By.id(OTHER_LIST_BOX_FOR_SORT_DATA_VIEW));
+        items = listBox.findElements(By.tagName(VAADIN_ITEM));
+
+        Assert.assertArrayEquals(
+                "Unexpected sorting for second radio button " + "group",
+                new String[] { "third", "first", "second" },
+                items.stream().map(WebElement::getText).toArray());
     }
 
     @Test

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.data.provider.BackEndDataProvider;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.IdentifierProvider;
@@ -51,12 +52,9 @@ import com.vaadin.flow.data.provider.ListDataView;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TextRenderer;
-import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableBiFunction;
-import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -435,77 +433,13 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     @SuppressWarnings("rawtypes")
     private Query getQuery() {
         return new Query<>(0, Integer.MAX_VALUE, null,
-                InnerListBoxListDataView.getComponentSortComparator(this)
-                        .orElse(null),
-                InnerListBoxListDataView.getComponentFilter(this).orElse(null));
+                DataViewUtils.getComponentSortComparator(this).orElse(null),
+                DataViewUtils.getComponentFilter(this).orElse(null));
     }
 
     private void removeFilteringAndSorting() {
-        InnerListBoxListDataView.removeComponentFilter(this);
-        InnerListBoxListDataView.removeComponentSortComparator(this);
+        DataViewUtils.removeComponentFilter(this);
+        DataViewUtils.removeComponentSortComparator(this);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static final class InnerListBoxListDataView
-            extends ListBoxListDataView {
-
-        private InnerListBoxListDataView(
-                SerializableSupplier dataProviderSupplier, ListBoxBase listBox,
-                SerializableBiConsumer dataChangedCallback) {
-            super(dataProviderSupplier, listBox, dataChangedCallback);
-        }
-
-        /**
-         * Gets the in-memory filter of a given ListBox instance.
-         *
-         * @param listBoxBase
-         *            ListBox instance the filter is bound to
-         * @param <T>
-         *            item type
-         * @return optional ListBox's in-memory filter.
-         */
-        static <T> Optional<SerializablePredicate<T>> getComponentFilter(
-                ListBoxBase listBoxBase) {
-            return ListBoxListDataView.getComponentFilter(listBoxBase);
-        }
-
-        /**
-         * Gets the in-memory sort comparator of a given ListBox instance.
-         *
-         * @param listBoxBase
-         *            ListBox instance the sort comparator is bound to
-         * @param <T>
-         *            item type
-         * @return optional ListBox's in-memory sort comparator.
-         */
-        static <T> Optional<SerializableComparator<T>> getComponentSortComparator(
-                ListBoxBase listBoxBase) {
-            return ListBoxListDataView.getComponentSortComparator(listBoxBase);
-        }
-
-        /**
-         * Removes the in-memory filter from a given ListBoxBase instance.
-         *
-         * @param listBoxBase
-         *            ListBoxBase instance the filter is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentFilter(ListBoxBase listBoxBase) {
-            ListBoxListDataView.setComponentFilter(listBoxBase, null);
-        }
-
-        /**
-         * Removes the in-memory sort comparator from a given ListBoxBase
-         * instance.
-         *
-         * @param listBoxBase
-         *            ListBoxBase instance the sort comparator is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentSortComparator(ListBoxBase listBoxBase) {
-            ListBoxListDataView.setComponentSortComparator(listBoxBase, null);
-        }
-    }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/ListBoxBase.java
@@ -100,7 +100,7 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
     @Deprecated
     public void setDataProvider(DataProvider<ITEM, ?> dataProvider) {
         this.dataProvider.set( Objects.requireNonNull(dataProvider) );
-        removeFilteringAndSorting();
+        DataViewUtils.removeComponentFilterAndSortComparator(this);
         setupDataProviderListener(this.dataProvider.get());
     }
 
@@ -219,7 +219,8 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
 
         synchronized (dataProvider) {
             final AtomicInteger itemCounter = new AtomicInteger(0);
-            items = (List<ITEM>) getDataProvider().fetch(getQuery())
+            items = (List<ITEM>) getDataProvider()
+                    .fetch(DataViewUtils.getQuery(this))
                     .collect(Collectors.toList());
             items.stream().map(this::createItemComponent)
                     .forEach(component -> {
@@ -428,18 +429,6 @@ public abstract class ListBoxBase<C extends ListBoxBase<C, ITEM, VALUE>, ITEM, V
             return dataProvider::getId;
 
         return IdentifierProvider.identity();
-    }
-
-    @SuppressWarnings("rawtypes")
-    private Query getQuery() {
-        return new Query<>(0, Integer.MAX_VALUE, null,
-                DataViewUtils.getComponentSortComparator(this).orElse(null),
-                DataViewUtils.getComponentFilter(this).orElse(null));
-    }
-
-    private void removeFilteringAndSorting() {
-        DataViewUtils.removeComponentFilter(this);
-        DataViewUtils.removeComponentSortComparator(this);
     }
 
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/dataview/ListBoxListDataView.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/dataview/ListBoxListDataView.java
@@ -41,14 +41,14 @@ public class ListBoxListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param listBox
      *            listBox instance for this DataView
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the ListBox's filtering
      *            or sorting changes, not <code>null</code>
      */
     public ListBoxListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             ListBoxBase listBox,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, listBox, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, listBox, filterOrSortingChangedCallback);
     }
 }

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/dataview/ListBoxListDataView.java
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/src/main/java/com/vaadin/flow/component/listbox/dataview/ListBoxListDataView.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.listbox.dataview;
 import com.vaadin.flow.component.listbox.ListBoxBase;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -38,10 +41,14 @@ public class ListBoxListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param listBox
      *            listBox instance for this DataView
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the ListBox's filtering
+     *            or sorting changes, not <code>null</code>
      */
     public ListBoxListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
-            ListBoxBase listBox) {
-        super(dataProviderSupplier, listBox);
+            ListBoxBase listBox,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, listBox, dataChangedCallback);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPage.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPage.java
@@ -15,6 +15,8 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupDataView;
 import com.vaadin.flow.component.radiobutton.dataview.RadioButtonGroupListDataView;
 import com.vaadin.flow.data.provider.AbstractDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
 
@@ -35,6 +37,10 @@ public class RadioButtonGroupDataViewPage extends Div {
     static final String RADIO_GROUP_FOR_NEXT_PREV_DATA_VIEW = "radio-group-for-next-prev-data-view";
     static final String RADIO_GROUP_FOR_SORT_DATA_VIEW = "radio-group-for-sort-data-view";
     static final String RADIO_GROUP_SELECTED_ID_SPAN = "radio-group-for-selected-ids-span";
+    static final String OTHER_RADIO_GROUP_FOR_ADD_TO_DATA_VIEW = "other-radio-group-for-add-to-data-view";
+    static final String OTHER_RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW = "other-radio-group-for-remove-from-data-view";
+    static final String OTHER_RADIO_GROUP_FOR_FILTER_DATA_VIEW = "other-radio-group-for-filter-data-view";
+    static final String OTHER_RADIO_GROUP_FOR_SORT_DATA_VIEW = "other-radio-group-for-sort-data-view";
 
     static final String DATA_VIEW_UPDATE_BUTTON = "data-view-update-button";
     static final String LIST_DATA_VIEW_UPDATE_BUTTON = "list-data-view-update-button";
@@ -116,14 +122,20 @@ public class RadioButtonGroupDataViewPage extends Div {
 
     private void createAddItemByDataView() {
         Item first = new Item(1L, FIRST);
-        List<Item> items = new ArrayList<>();
-        items.add(first);
 
         RadioButtonGroup<Item> rbgForAddToDataView = new RadioButtonGroup<>();
         rbgForAddToDataView.setId(RADIO_GROUP_FOR_ADD_TO_DATA_VIEW);
 
+        RadioButtonGroup<Item> otherRbgForAddToDataView = new RadioButtonGroup<>();
+        otherRbgForAddToDataView.setId(OTHER_RADIO_GROUP_FOR_ADD_TO_DATA_VIEW);
+
+        final ListDataProvider<Item> listDataProvider = DataProvider
+                .ofItems(first);
+
         RadioButtonGroupListDataView<Item> dataView = rbgForAddToDataView
-                .setItems(items);
+                .setItems(listDataProvider);
+
+        otherRbgForAddToDataView.setItems(listDataProvider);
 
         NativeButton dataViewAddButton = new NativeButton("Add", click -> {
             Item second = new Item(2L, SECOND);
@@ -131,32 +143,50 @@ public class RadioButtonGroupDataViewPage extends Div {
         });
         dataViewAddButton.setId(LIST_DATA_VIEW_ADD_BUTTON);
 
-        add(rbgForAddToDataView, dataViewAddButton);
+        add(rbgForAddToDataView, otherRbgForAddToDataView, dataViewAddButton);
     }
 
     private void createRemoveItemByDataView() {
         Item first = new Item(1L, FIRST);
         Item second = new Item(2L, SECOND);
-        List<Item> items = new ArrayList<>(Arrays.asList(first, second));
 
         RadioButtonGroup<Item> rbgForRemoveFromDataView = new RadioButtonGroup<>();
         rbgForRemoveFromDataView.setId(RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW);
 
+        RadioButtonGroup<Object> otherRbgForRemoveFromDataView = new RadioButtonGroup<>();
+        otherRbgForRemoveFromDataView
+                .setId(OTHER_RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW);
+
+        ListDataProvider<Item> listDataProvider = DataProvider.ofItems(first,
+                second);
+
         RadioButtonGroupListDataView<Item> dataView = rbgForRemoveFromDataView
-                .setItems(items);
+                .setItems(listDataProvider);
+
+        otherRbgForRemoveFromDataView.setItems(listDataProvider);
 
         NativeButton dataViewRemoveButton = new NativeButton("Remove",
                 click -> dataView.removeItem(second));
         dataViewRemoveButton.setId(LIST_DATA_VIEW_REMOVE_BUTTON);
 
-        add(rbgForRemoveFromDataView, dataViewRemoveButton);
+        add(rbgForRemoveFromDataView, otherRbgForRemoveFromDataView,
+                dataViewRemoveButton);
     }
 
     private void createFilterItemsByDataView() {
         RadioButtonGroup<Integer> numbers = new RadioButtonGroup<>();
         numbers.setId(RADIO_GROUP_FOR_FILTER_DATA_VIEW);
+
+        RadioButtonGroup<Integer> otherNumbers = new RadioButtonGroup<>();
+        otherNumbers.setId(OTHER_RADIO_GROUP_FOR_FILTER_DATA_VIEW);
+
+        final ListDataProvider<Integer> listDataProvider = DataProvider
+                .ofItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
         RadioButtonGroupListDataView<Integer> numbersDataView = numbers
-                .setItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .setItems(listDataProvider);
+
+        otherNumbers.setItems(listDataProvider);
 
         NativeButton filterOdds = new NativeButton("Filter Odds",
                 click -> numbersDataView.setFilter(num -> num % 2 == 0));
@@ -171,7 +201,8 @@ public class RadioButtonGroupDataViewPage extends Div {
                 click -> numbersDataView.removeFilters());
         noFilter.setId(LIST_DATA_VIEW_REMOVE_FILTER_BUTTON);
 
-        add(numbers, filterOdds, filterMultiplesOfThree, noFilter);
+        add(numbers, otherNumbers, filterOdds, filterMultiplesOfThree,
+                noFilter);
     }
 
     private void createNextPreviousItemDataView() {
@@ -225,20 +256,27 @@ public class RadioButtonGroupDataViewPage extends Div {
         Item first = new Item(1L, FIRST);
         Item second = new Item(2L, SECOND);
         Item third = new Item(3L, THIRD);
-        List<Item> items = new ArrayList<>(Arrays.asList(third, first, second));
 
         RadioButtonGroup<Item> rbgForSortDataView = new RadioButtonGroup<>();
         rbgForSortDataView.setId(RADIO_GROUP_FOR_SORT_DATA_VIEW);
 
+        RadioButtonGroup<Item> otherRbgForSortDataView = new RadioButtonGroup<>();
+        otherRbgForSortDataView.setId(OTHER_RADIO_GROUP_FOR_SORT_DATA_VIEW);
+
+        final ListDataProvider<Item> listDataProvider = DataProvider
+                .ofItems(third, first, second);
+
         RadioButtonGroupListDataView<Item> dataView = rbgForSortDataView
-                .setItems(items);
+                .setItems(listDataProvider);
+
+        otherRbgForSortDataView.setItems(listDataProvider);
 
         NativeButton dataViewSortButton = new NativeButton("Sort",
                 click -> dataView.setSortComparator((item1, item2) -> item1
                         .getValue().compareToIgnoreCase(item2.getValue())));
         dataViewSortButton.setId(LIST_DATA_VIEW_SORT_BUTTON);
 
-        add(rbgForSortDataView, dataViewSortButton);
+        add(rbgForSortDataView, otherRbgForSortDataView, dataViewSortButton);
     }
 
     private void createIdentifierProviderForListBox() {

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPageIT.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/test/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDataViewPageIT.java
@@ -2,14 +2,13 @@ package com.vaadin.flow.component.radiobutton.tests;
 
 import java.util.List;
 
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-
-import com.vaadin.tests.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
 
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.CURRENT_ITEM_SPAN;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.DATA_VIEW_UPDATE_BUTTON;
@@ -24,6 +23,10 @@ import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataVi
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.LIST_DATA_VIEW_SET_FILTER_BUTTON;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.LIST_DATA_VIEW_SORT_BUTTON;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.LIST_DATA_VIEW_UPDATE_BUTTON;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.OTHER_RADIO_GROUP_FOR_ADD_TO_DATA_VIEW;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.OTHER_RADIO_GROUP_FOR_FILTER_DATA_VIEW;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.OTHER_RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW;
+import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.OTHER_RADIO_GROUP_FOR_SORT_DATA_VIEW;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_ADD_TO_DATA_VIEW;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_DATA_VIEW;
 import static com.vaadin.flow.component.radiobutton.tests.RadioButtonGroupDataViewPage.RADIO_GROUP_FOR_FILTER_DATA_VIEW;
@@ -109,6 +112,12 @@ public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
 
         Assert.assertEquals("Second RadioButton should have the text", SECOND,
                 buttons.get(1).getText());
+
+        group = findElement(By.id(OTHER_RADIO_GROUP_FOR_ADD_TO_DATA_VIEW));
+        buttons = group.findElements(By.tagName(VAADIN_RADIO_BUTTON));
+
+        Assert.assertEquals("Unexpected item count after adding a new one", 2,
+                buttons.size());
     }
 
     @Test
@@ -132,6 +141,12 @@ public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
 
         Assert.assertEquals("First RadioButton should have the text", FIRST,
                 buttons.get(0).getText());
+
+        group = findElement(By.id(OTHER_RADIO_GROUP_FOR_REMOVE_FROM_DATA_VIEW));
+        buttons = group.findElements(By.tagName(VAADIN_RADIO_BUTTON));
+
+        Assert.assertEquals("Unexpected item count after removing an item", 1,
+                buttons.size());
     }
 
     @Test
@@ -150,6 +165,13 @@ public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
         buttons = group.findElements(By.tagName(VAADIN_RADIO_BUTTON));
 
         Assert.assertEquals("Group should have buttons", 5, buttons.size());
+
+        group = findElement(By.id(OTHER_RADIO_GROUP_FOR_FILTER_DATA_VIEW));
+        buttons = group.findElements(By.tagName(VAADIN_RADIO_BUTTON));
+
+        Assert.assertEquals(
+                "Filtering is not expected for second radio " + "button group",
+                10, buttons.size());
 
         findElement(By.id(LIST_DATA_VIEW_ADD_FILTER_BUTTON)).click();
         waitForElementPresent(By.tagName(VAADIN_RADIO_BUTTON));
@@ -234,6 +256,14 @@ public class RadioButtonGroupDataViewPageIT extends AbstractComponentIT {
                 "second", buttons.get(1).getText());
         Assert.assertEquals("third rendered radio button's text should be",
                 "third", buttons.get(2).getText());
+
+        group = findElement(By.id(OTHER_RADIO_GROUP_FOR_SORT_DATA_VIEW));
+        buttons = group.findElements(By.tagName(VAADIN_RADIO_BUTTON));
+
+        Assert.assertArrayEquals(
+                "Sorting is not expected for second radio button group",
+                new String[] { "third", "first", "second" },
+                buttons.stream().map(WebElement::getText).toArray());
     }
 
     @Test

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.IdentifierProvider;
@@ -50,11 +51,8 @@ import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.dom.PropertyChangeEvent;
 import com.vaadin.flow.dom.PropertyChangeListener;
-import com.vaadin.flow.function.SerializableBiConsumer;
-import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -589,87 +587,12 @@ public class RadioButtonGroup<T>
     @SuppressWarnings("rawtypes")
     private Query getQuery() {
         return new Query<>(0, Integer.MAX_VALUE, null,
-                InnerRadioButtonGroupListDataView
-                        .getComponentSortComparator(this).orElse(null),
-                InnerRadioButtonGroupListDataView.getComponentFilter(this)
-                        .orElse(null));
+                DataViewUtils.getComponentSortComparator(this).orElse(null),
+                DataViewUtils.getComponentFilter(this).orElse(null));
     }
 
     private void removeFilteringAndSorting() {
-        InnerRadioButtonGroupListDataView.removeComponentFilter(this);
-        InnerRadioButtonGroupListDataView.removeComponentSortComparator(this);
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static final class InnerRadioButtonGroupListDataView
-            extends RadioButtonGroupListDataView {
-
-        private InnerRadioButtonGroupListDataView(
-                SerializableSupplier dataProviderSupplier,
-                RadioButtonGroup radioButtonGroup,
-                SerializableBiConsumer dataChangedCallback) {
-            super(dataProviderSupplier, radioButtonGroup, dataChangedCallback);
-        }
-
-        /**
-         * Gets the in-memory filter of a given RadioButtonGroup instance.
-         *
-         * @param radioButtonGroup
-         *            RadioButtonGroup instance the filter is bound to
-         * @param <T>
-         *            item type
-         * @return optional RadioButtonGroup's in-memory filter.
-         */
-        public static <T> Optional<SerializablePredicate<T>> getComponentFilter(
-                RadioButtonGroup<T> radioButtonGroup) {
-            return RadioButtonGroupListDataView
-                    .getComponentFilter(radioButtonGroup);
-        }
-
-        /**
-         * Gets the in-memory sort comparator of a given RadioButtonGroup
-         * instance.
-         *
-         * @param radioButtonGroup
-         *            RadioButtonGroup instance the sort comparator is bound to
-         * @param <T>
-         *            item type
-         * @return optional RadioButtonGroup's in-memory sort comparator.
-         */
-        public static <T> Optional<SerializableComparator<T>> getComponentSortComparator(
-                RadioButtonGroup<T> radioButtonGroup) {
-            return RadioButtonGroupListDataView
-                    .getComponentSortComparator(radioButtonGroup);
-        }
-
-        /**
-         * Removes the in-memory filter from a given RadioButtonGroup instance.
-         *
-         * @param radioButtonGroup
-         *            RadioButtonGroup instance the filter is removed from
-         * @param <T>
-         *            items type
-         */
-        public static <T> void removeComponentFilter(
-                RadioButtonGroup<T> radioButtonGroup) {
-            RadioButtonGroupListDataView.setComponentFilter(radioButtonGroup,
-                    null);
-        }
-
-        /**
-         * Removes the in-memory sort comparator from a given RadioButtonGroup
-         * instance.
-         *
-         * @param radioButtonGroup
-         *            RadioButtonGroup instance the sort comparator is removed
-         *            from
-         * @param <T>
-         *            items type
-         */
-        public static <T> void removeComponentSortComparator(
-                RadioButtonGroup<T> radioButtonGroup) {
-            RadioButtonGroupListDataView
-                    .setComponentSortComparator(radioButtonGroup, null);
-        }
+        DataViewUtils.removeComponentFilter(this);
+        DataViewUtils.removeComponentSortComparator(this);
     }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroup.java
@@ -212,7 +212,7 @@ public class RadioButtonGroup<T>
     @Deprecated
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
-        removeFilteringAndSorting();
+        DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
 
         setupDataProviderListener(dataProvider);
@@ -421,7 +421,8 @@ public class RadioButtonGroup<T>
 
         synchronized (dataProvider) {
             final AtomicInteger itemCounter = new AtomicInteger(0);
-            getDataProvider().fetch(getQuery()).map(item -> createRadioButton((T) item))
+            getDataProvider().fetch(DataViewUtils.getQuery(this))
+                    .map(item -> createRadioButton((T) item))
                     .forEach(component -> {
                         add((Component) component);
                         itemCounter.incrementAndGet();
@@ -584,15 +585,4 @@ public class RadioButtonGroup<T>
         keyMapper.setIdentifierGetter(identifierProvider);
     }
 
-    @SuppressWarnings("rawtypes")
-    private Query getQuery() {
-        return new Query<>(0, Integer.MAX_VALUE, null,
-                DataViewUtils.getComponentSortComparator(this).orElse(null),
-                DataViewUtils.getComponentFilter(this).orElse(null));
-    }
-
-    private void removeFilteringAndSorting() {
-        DataViewUtils.removeComponentFilter(this);
-        DataViewUtils.removeComponentSortComparator(this);
-    }
 }

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -15,11 +15,16 @@
  */
 package com.vaadin.flow.component.radiobutton.dataview;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -42,11 +47,15 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param radioButtonGroup
      *            radioButton Group instance for this DataView
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the RadioButtonGroup's
+     *            filtering or sorting changes, not <code>null</code>
      */
     public RadioButtonGroupListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
-            RadioButtonGroup radioButtonGroup) {
-        super(dataProviderSupplier, radioButtonGroup);
+            RadioButtonGroup radioButtonGroup,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup, dataChangedCallback);
     }
 
     /**
@@ -60,12 +69,16 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the RadioButtonGroup's
+     *            filtering or sorting changes, not <code>null</code>
      */
     public RadioButtonGroupListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             RadioButtonGroup radioButtonGroup,
-            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
-        super(dataProviderSupplier, radioButtonGroup);
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup, dataChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/dataview/RadioButtonGroupListDataView.java
@@ -47,15 +47,15 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
      *            data provider supplier
      * @param radioButtonGroup
      *            radioButton Group instance for this DataView
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the RadioButtonGroup's
      *            filtering or sorting changes, not <code>null</code>
      */
     public RadioButtonGroupListDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             RadioButtonGroup radioButtonGroup,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, radioButtonGroup, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup, filterOrSortingChangedCallback);
     }
 
     /**
@@ -69,7 +69,7 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the RadioButtonGroup's
      *            filtering or sorting changes, not <code>null</code>
      */
@@ -77,8 +77,8 @@ public class RadioButtonGroupListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             RadioButtonGroup radioButtonGroup,
             SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
-            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, radioButtonGroup, dataChangedCallback);
+            SerializableBiConsumer<SerializablePredicate<T>, SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, radioButtonGroup, filterOrSortingChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/SelectListDataViewPage.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/SelectListDataViewPage.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.component.select.examples;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -10,11 +8,14 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.select.data.SelectListDataView;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-select-list-data-view")
 public class SelectListDataViewPage extends Div {
     public static final String SELECT = "select-data-view";
+    public static final String OTHER_SELECT = "other-select-data-view";
     public static final String ITEMS_SIZE = "size-span-data-view";
     public static final String ITEM_PRESENT = "item-present-span-data-view";
     public static final String ALL_ITEMS = "all-items-span-data-view";
@@ -38,14 +39,17 @@ public class SelectListDataViewPage extends Div {
 
     public SelectListDataViewPage() {
         Select<Person> select = new Select<>();
+        Select<Person> otherSelect = new Select<>();
+
         Person john = new Person(1, "John");
         Person paul = new Person(2, "Paul");
         Person mike = new Person(3, "Mike");
 
-        SelectListDataView<Person> dataView =
-                select.setItems(new ArrayList<>(Arrays.asList(
-                john, paul, mike)
-        ));
+        final ListDataProvider<Person> dataProvider = DataProvider.ofItems(john,
+                paul, mike);
+
+        SelectListDataView<Person> dataView = select.setItems(dataProvider);
+        otherSelect.setItems(dataProvider);
 
         Span sizeSpan = new Span(String.valueOf(dataView.getItemCount()));
         Span containsItemSpan = new Span(String.valueOf(
@@ -92,15 +96,16 @@ public class SelectListDataViewPage extends Div {
         NativeButton updateName = new NativeButton("Update first name",
                 event -> {
                     Person updatedPerson =
-                            dataView.getItem(3);
+                            dataView.getItem(0);
                     updatedPerson.setName("Jack");
                     dataView.refreshItem(updatedPerson);
                 });
         NativeButton deletePerson = new NativeButton("Delete person",
                 event -> dataView.removeItem(
-                        new Person(4, null)));
+                        new Person(1, null)));
 
         select.setId(SELECT);
+        otherSelect.setId(OTHER_SELECT);
         sizeSpan.setId(ITEMS_SIZE);
         containsItemSpan.setId(ITEM_PRESENT);
         allItemsSpan.setId(ALL_ITEMS);
@@ -119,7 +124,7 @@ public class SelectListDataViewPage extends Div {
         add(select, sizeSpan, containsItemSpan, allItemsSpan,
                 itemOnIndexSpan, currentItemSpan, hasNextItemSpan,
                 hasPrevItemSpan, filterButton, sortButton, nextItemButton,
-                prevItemButton, addNew, updateName, deletePerson);
+                prevItemButton, addNew, updateName, deletePerson, otherSelect);
     }
 
     public static class Person {

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/SelectListDataViewIT.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/SelectListDataViewIT.java
@@ -4,23 +4,33 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.select.examples.SelectListDataViewPage;
 import com.vaadin.flow.component.select.testbench.SelectElement;
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 @TestPath("vaadin-select-list-data-view")
 public class SelectListDataViewIT extends AbstractComponentIT {
 
-    @Test
-    public void selectListDataView_dataViewApiRequested_dataAvailable() {
+    private SelectElement select;
+    private SelectElement otherSelect;
+
+    @Before
+    public void init() {
         open();
 
-        SelectElement select = $(SelectElement.class)
+        select = $(SelectElement.class)
                 .id(SelectListDataViewPage.SELECT);
 
+        otherSelect = $(SelectElement.class)
+                .id(SelectListDataViewPage.OTHER_SELECT);
+    }
+
+    @Test
+    public void getItems_showsCheckboxContent() {
         // Select items size
         Assert.assertEquals("Unexpected select size", 3,
                 select.getItems().size());
@@ -32,7 +42,10 @@ public class SelectListDataViewIT extends AbstractComponentIT {
         // Item present
         Assert.assertEquals("Person 'John' is expected to be present", "true",
                 $("span").id(SelectListDataViewPage.ITEM_PRESENT).getText());
+    }
 
+    @Test
+    public void navigateBetweenItems_showCorrectItems() {
         // Item on index
         Assert.assertEquals("Person 'John' is expected on index 0", "John",
                 $("span").id(SelectListDataViewPage.ITEM_ON_INDEX).getText());
@@ -56,34 +69,75 @@ public class SelectListDataViewIT extends AbstractComponentIT {
         // Previous item
         Assert.assertEquals("Unexpected previous item", "Paul",
                 $("span").id(SelectListDataViewPage.CURRENT_ITEM).getText());
+    }
 
-        // Add item
+    @Test
+    public void addItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(SelectListDataViewPage.ADD_ITEM)).click();
-        Assert.assertEquals("Wrong name for added person", "Peter",
+
+        Assert.assertEquals("Unexpected item count after adding a new item in"
+                + " first select", 4, select.getItems().size());
+        Assert.assertEquals("Wrong name for added person in first select",
+                "Peter",
                 select.getItems().get(3).getText());
 
-        // Update item
+        Assert.assertEquals("Unexpected item count after adding a new item in"
+                + " second select", 4, otherSelect.getItems().size());
+        Assert.assertEquals("Wrong name for added person in second select",
+                "Peter", otherSelect.getItems().get(3).getText());
+    }
+
+    @Test
+    public void updateItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(SelectListDataViewPage.UPDATE_ITEM)).click();
-        Assert.assertEquals("Wrong name for updated person", "Jack",
-                select.getItems().get(3).getText());
 
-        // Delete item
+        Assert.assertEquals("Wrong name for updated person", "Jack",
+                select.getItems().get(0).getText());
+
+        Assert.assertEquals("Wrong name for updated person", "Jack",
+                otherSelect.getItems().get(0).getText());
+    }
+
+    @Test
+    public void deleteItem_itemAddedAndShownInBothComponents() {
         findElement(By.id(SelectListDataViewPage.DELETE_ITEM)).click();
-        Assert.assertEquals("Item count not expected", 3,
+
+        Assert.assertEquals("Item count not expected", 2,
                 select.getItems().size());
 
-        // Sort order
+        Assert.assertEquals("Item count not expected", 2,
+                otherSelect.getItems().size());
+    }
+
+    @Test
+    public void sorting_itemsSortedOnlyInOneComponent() {
         findElement(By.id(SelectListDataViewPage.SORT_BUTTON)).click();
+
         Assert.assertEquals("Unexpected sort order", "John,Mike,Paul",
-                select.getItems().stream().map(TestBenchElement::getText)
+                select.$("vaadin-item").all().stream()
+                        .map(TestBenchElement::getText)
                         .collect(Collectors.joining(",")));
 
+        Assert.assertEquals("Unexpected sort order", "John,Paul,Mike",
+                otherSelect.$("vaadin-item").all().stream()
+                        .map(TestBenchElement::getText)
+                        .collect(Collectors.joining(",")));
+    }
+
+    @Test
+    public void filtering_itemsFilteredOnlyInOneComponent() {
         findElement(By.id(SelectListDataViewPage.FILTER_BUTTON)).click();
 
-        // Filtering
-        Assert.assertEquals("Unexpected filtered checkbox count", 1,
-                select.getItems().size());
-        Assert.assertEquals("Unexpected filtered checkbox item", "Paul",
-                select.getItems().get(0).getText());
+        Assert.assertEquals("Unexpected filtered items count", 1,
+                select.$("vaadin-item").all().size());
+        Assert.assertEquals("Unexpected filtered item", "Paul",
+                select.$("vaadin-item").all().get(0).getText());
+
+        Assert.assertEquals("No filter expected", 3,
+                otherSelect.$("vaadin-item").all().size());
+        Assert.assertArrayEquals("No filter expected",
+                new String[] { "John", "Paul", "Mike" },
+                otherSelect.$("vaadin-item").all().stream()
+                        .map(TestBenchElement::getText).toArray());
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
 import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.DataProviderWrapper;
+import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.flow.data.provider.HasDataView;
 import com.vaadin.flow.data.provider.HasListDataView;
 import com.vaadin.flow.data.provider.IdentifierProvider;
@@ -54,11 +55,8 @@ import com.vaadin.flow.data.renderer.TextRenderer;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.dom.PropertyChangeEvent;
 import com.vaadin.flow.dom.PropertyChangeListener;
-import com.vaadin.flow.function.SerializableBiConsumer;
-import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -1003,76 +1001,12 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
     @SuppressWarnings("rawtypes")
     private Query getQuery() {
         return new Query<>(0, Integer.MAX_VALUE, null,
-                InnerSelectListDataView.getComponentSortComparator(this)
-                        .orElse(null),
-                InnerSelectListDataView.getComponentFilter(this).orElse(null));
+                DataViewUtils.getComponentSortComparator(this).orElse(null),
+                DataViewUtils.getComponentFilter(this).orElse(null));
     }
 
     private void removeFilteringAndSorting() {
-        InnerSelectListDataView.removeComponentFilter(this);
-        InnerSelectListDataView.removeComponentSortComparator(this);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static final class InnerSelectListDataView
-            extends SelectListDataView {
-
-        private InnerSelectListDataView(
-                SerializableSupplier dataProviderSupplier, Select select,
-                SerializableBiConsumer dataChangedCallback) {
-            super(dataProviderSupplier, select, dataChangedCallback);
-        }
-
-        /**
-         * Gets the in-memory filter of a given Select instance.
-         *
-         * @param select
-         *            Select instance the filter is bound to
-         * @param <T>
-         *            item type
-         * @return optional Select's in-memory filter.
-         */
-        static <T> Optional<SerializablePredicate<T>> getComponentFilter(
-                Select<T> select) {
-            return SelectListDataView.getComponentFilter(select);
-        }
-
-        /**
-         * Gets the in-memory sort comparator of a given Select instance.
-         *
-         * @param select
-         *            Select instance the sort comparator is bound to
-         * @param <T>
-         *            item type
-         * @return optional Select's in-memory sort comparator.
-         */
-        static <T> Optional<SerializableComparator<T>> getComponentSortComparator(
-                Select<T> select) {
-            return SelectListDataView.getComponentSortComparator(select);
-        }
-
-        /**
-         * Removes the in-memory filter from a given Select instance.
-         *
-         * @param select
-         *            Select instance the filter is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentFilter(Select<T> select) {
-            SelectListDataView.setComponentFilter(select, null);
-        }
-
-        /**
-         * Removes the in-memory sort comparator from a given Select instance.
-         *
-         * @param select
-         *            Select instance the sort comparator is removed from
-         * @param <T>
-         *            items type
-         */
-        static <T> void removeComponentSortComparator(Select<T> select) {
-            SelectListDataView.setComponentSortComparator(select, null);
-        }
+        DataViewUtils.removeComponentFilter(this);
+        DataViewUtils.removeComponentSortComparator(this);
     }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -451,7 +451,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
     @Deprecated
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         this.dataProvider.set(dataProvider);
-        removeFilteringAndSorting();
+        DataViewUtils.removeComponentFilterAndSortComparator(this);
         reset();
 
         if (dataProviderListenerRegistration != null) {
@@ -856,7 +856,7 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
 
         synchronized (dataProvider) {
             final AtomicInteger itemCounter = new AtomicInteger(0);
-            getDataProvider().fetch(getQuery()).map(item -> createItem((T) item))
+            getDataProvider().fetch(DataViewUtils.getQuery(this)).map(item -> createItem((T) item))
                     .forEach(component -> {
                         add((Component) component);
                         itemCounter.incrementAndGet();
@@ -998,15 +998,4 @@ public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         keyMapper.setIdentifierGetter(identifierProvider);
     }
 
-    @SuppressWarnings("rawtypes")
-    private Query getQuery() {
-        return new Query<>(0, Integer.MAX_VALUE, null,
-                DataViewUtils.getComponentSortComparator(this).orElse(null),
-                DataViewUtils.getComponentFilter(this).orElse(null));
-    }
-
-    private void removeFilteringAndSorting() {
-        DataViewUtils.removeComponentFilter(this);
-        DataViewUtils.removeComponentSortComparator(this);
-    }
 }

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
@@ -29,7 +29,7 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
      *            supplier from which the DataProvider can be gotten
      * @param select
      *            select component that the dataView is bound to
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the Select's filtering
      *            or sorting changes, not <code>null</code>
      */
@@ -37,8 +37,8 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             Select<T> select,
             SerializableBiConsumer<SerializablePredicate<T>,
-                    SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, select, dataChangedCallback);
+                    SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, select, filterOrSortingChangedCallback);
     }
 
     /**
@@ -52,7 +52,7 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
-     * @param dataChangedCallback
+     * @param filterOrSortingChangedCallback
      *            callback, which is being invoked when the Select's filtering
      *            or sorting changes, not <code>null</code>
      */
@@ -61,8 +61,8 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
             Select<T> select,
             SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
             SerializableBiConsumer<SerializablePredicate<T>,
-                    SerializableComparator<T>> dataChangedCallback) {
-        super(dataProviderSupplier, select, dataChangedCallback);
+                    SerializableComparator<T>> filterOrSortingChangedCallback) {
+        super(dataProviderSupplier, select, filterOrSortingChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/data/SelectListDataView.java
@@ -4,7 +4,10 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.data.provider.AbstractListDataView;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 
 /**
@@ -26,11 +29,16 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
      *            supplier from which the DataProvider can be gotten
      * @param select
      *            select component that the dataView is bound to
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the Select's filtering
+     *            or sorting changes, not <code>null</code>
      */
     public SelectListDataView(
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
-            Select<T> select) {
-        super(dataProviderSupplier, select);
+            Select<T> select,
+            SerializableBiConsumer<SerializablePredicate<T>,
+                    SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, select, dataChangedCallback);
     }
 
     /**
@@ -44,12 +52,17 @@ public class SelectListDataView<T> extends AbstractListDataView<T> {
      * @param identifierChangedCallback
      *            callback method which should be called when identifierProvider
      *            is changed
+     * @param dataChangedCallback
+     *            callback, which is being invoked when the Select's filtering
+     *            or sorting changes, not <code>null</code>
      */
     public SelectListDataView(
             SerializableSupplier<DataProvider<T, ?>> dataProviderSupplier,
             Select<T> select,
-            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback) {
-        super(dataProviderSupplier, select);
+            SerializableConsumer<IdentifierProvider<T>> identifierChangedCallback,
+            SerializableBiConsumer<SerializablePredicate<T>,
+                    SerializableComparator<T>> dataChangedCallback) {
+        super(dataProviderSupplier, select, dataChangedCallback);
         this.identifierChangedCallback = identifierChangedCallback;
     }
 


### PR DESCRIPTION
In-memory filtering and sorting are now stored directly in component, which gives an opportunity to change it through the data view API for a certain component separately from other components bound to the same data provider.

Fixes: https://github.com/vaadin/flow/issues/8655