### PR TITLE
fix: update combo-box integration tests (#365)

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -375,8 +375,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         filterBox.setFilter("Person");
 
-        Assert.assertEquals("None of the items should match the filter.", 0,
-                getNonEmptyOverlayContents().size());
+        Assert.assertEquals("None of the items should match the filter " +
+                        "and overlay is not displayed", 0,
+                $("vaadin-combo-box-overlay").all().size());
 
         filterBox.setFilter("10");
 
@@ -465,7 +466,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         Assert.assertEquals(item, getSelectedItemLabel(stringBox));
     }
 
-    @Test 
+    @Test
     public void autoOpenDisabled_setValue_valueChanged() {
         String item = "Item 151";
         stringBox.openPopup();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -295,8 +295,8 @@ import elemental.json.JsonObject;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.5-SNAPSHOT",
         "WebComponent: Vaadin.ComboBoxElement#5.0.0", "Flow#1.5-SNAPSHOT" })
 @Tag("vaadin-combo-box")
-@NpmPackage(value = "@vaadin/vaadin-combo-box", version = "5.4.3")
 @HtmlImport("frontend://bower_components/vaadin-combo-box/src/vaadin-combo-box.html")
+@NpmPackage(value = "@vaadin/vaadin-combo-box", version = "5.4.5")
 @JsModule("@vaadin/vaadin-combo-box/src/vaadin-combo-box.js")
 public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<R, T>, T>
         extends AbstractSinglePropertyField<R, T>


### PR DESCRIPTION
Web-component: combo-box

Fixes: https://github.com/vaadin/vaadin-combo-box/issues/965

Details: with the update of 5.4.4 wc overlay is closed when there is no items filter, so `customItemFilter` test should be updated as well.