### PR TITLE
fix: clear ComboBox filter on drop down close

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewPage.java
@@ -26,14 +26,14 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
-@Route("combobox-lazy-data-view-page")
+@Route("vaadin-combo-box/combobox-lazy-data-view-page")
 public class ComboBoxLazyDataViewPage extends Div {
 
-    public static final String COMBO_BOX_ID = "combo-box-get-items-page";
-    public static final String ITEMS_LIST_ID = "items-list";
-    public static final String GET_ITEMS_BUTTON_ID = "get-items-button";
-    public static final String GET_ITEM_BUTTON_ID = "get-item-button";
-    public static final String SWITCH_BUTTON_ID = "switch-to-unknown-button";
+    static final String COMBO_BOX_ID = "combo-box-get-items-page";
+    static final String ITEMS_LIST_ID = "items-list";
+    static final String GET_ITEMS_BUTTON_ID = "get-items-button";
+    static final String GET_ITEM_BUTTON_ID = "get-item-button";
+    static final String SWITCH_TO_UNKNOWN_COUNT_BUTTON_ID = "switch-to-unknown-button";
 
     public ComboBoxLazyDataViewPage() {
 
@@ -68,7 +68,7 @@ public class ComboBoxLazyDataViewPage extends Div {
         NativeButton switchToUnknown = new NativeButton(
                 "Switch To Unknown Item Count",
                 click -> dataView.setItemCountUnknown());
-        switchToUnknown.setId(SWITCH_BUTTON_ID);
+        switchToUnknown.setId(SWITCH_TO_UNKNOWN_COUNT_BUTTON_ID);
 
         add(comboBox, switchToUnknown, getItemButton, getItemsButton,
                 itemsList);

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewPage.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("combobox-lazy-data-view-page")
+public class ComboBoxLazyDataViewPage extends Div {
+
+    public static final String COMBO_BOX_ID = "combo-box-get-items-page";
+    public static final String ITEMS_LIST_ID = "items-list";
+    public static final String GET_ITEMS_BUTTON_ID = "get-items-button";
+    public static final String GET_ITEM_BUTTON_ID = "get-item-button";
+    public static final String SWITCH_BUTTON_ID = "switch-to-unknown-button";
+
+    public ComboBoxLazyDataViewPage() {
+
+        ComboBox<String> comboBox = new ComboBox<>();
+        ComboBoxLazyDataView<String> dataView = comboBox.setItems(
+                query -> IntStream.range(0, 1000)
+                        .mapToObj(index -> "Item " + index)
+                        .filter(item -> item
+                                .contains(query.getFilter().orElse("")))
+                        .skip(query.getOffset()).limit(query.getLimit()),
+                query -> (int) IntStream.range(0, 1000)
+                        .mapToObj(index -> "Item " + index)
+                        .filter(item -> item
+                                .contains(query.getFilter().orElse("")))
+                        .count());
+
+        comboBox.setId(COMBO_BOX_ID);
+
+        Span itemsList = new Span("Items shown here");
+        itemsList.setId(ITEMS_LIST_ID);
+
+        NativeButton getItemsButton = new NativeButton("Get Items", click -> {
+            itemsList.setText(
+                    dataView.getItems().collect(Collectors.joining(",")));
+        });
+        getItemsButton.setId(GET_ITEMS_BUTTON_ID);
+
+        NativeButton getItemButton = new NativeButton("Get Item",
+                click -> itemsList.setText(dataView.getItem(0)));
+        getItemButton.setId(GET_ITEM_BUTTON_ID);
+
+        NativeButton switchToUnknown = new NativeButton(
+                "Switch To Unknown Item Count",
+                click -> dataView.setItemCountUnknown());
+        switchToUnknown.setId(SWITCH_BUTTON_ID);
+
+        add(comboBox, switchToUnknown, getItemButton, getItemsButton,
+                itemsList);
+    }
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
@@ -49,6 +49,8 @@ public class ComboBoxListDataViewPage extends Div {
     public static final String REMOVE_ITEM = "removeItem";
     public static final String REVERSE_SORTING = "reverseSorting";
 
+    public static final String NEW_PERSON_NAME = "Person NEW";
+
     public ComboBoxListDataViewPage() {
         List<Person> personList = generatePersonItems();
         final ListDataProvider<Person> dataProvider = DataProvider

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
@@ -32,24 +32,24 @@ import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.router.Route;
 
-@Route("combobox-list-data-view-page")
+@Route("vaadin-combo-box/combobox-list-data-view-page")
 public class ComboBoxListDataViewPage extends Div {
 
-    public static final String FIRST_COMBO_BOX_ID = "first-combo-box";
-    public static final String SECOND_COMBO_BOX_ID = "second-combo-box";
-    public static final String ITEM_COUNT = "itemCount";
-    public static final String ITEM_DATA = "itemData";
-    public static final String ITEM_SELECT = "itemSelect";
-    public static final String SHOW_ITEM_DATA = "showItemData";
-    public static final String SHOW_NEXT_DATA = "showNextData";
-    public static final String SHOW_PREVIOUS_DATA = "showPreviousData";
-    public static final String SHOW_ITEM_COUNT = "showItemCount";
-    public static final String SHOW_ITEMS = "showItems";
-    public static final String AGE_FILTER = "ageFilter";
-    public static final String REMOVE_ITEM = "removeItem";
-    public static final String REVERSE_SORTING = "reverseSorting";
+    static final String FIRST_COMBO_BOX_ID = "first-combo-box";
+    static final String SECOND_COMBO_BOX_ID = "second-combo-box";
+    static final String ITEM_COUNT = "itemCount";
+    static final String ITEM_DATA = "itemData";
+    static final String ITEM_SELECT = "itemSelect";
+    static final String SHOW_ITEM_DATA = "showItemData";
+    static final String SHOW_NEXT_DATA = "showNextData";
+    static final String SHOW_PREVIOUS_DATA = "showPreviousData";
+    static final String SHOW_ITEM_COUNT = "showItemCount";
+    static final String SHOW_ITEMS = "showItems";
+    static final String AGE_FILTER = "ageFilter";
+    static final String REMOVE_ITEM = "removeItem";
+    static final String REVERSE_SORTING = "reverseSorting";
 
-    public static final String NEW_PERSON_NAME = "Person NEW";
+    static final String NEW_PERSON_NAME = "Person NEW";
 
     public ComboBoxListDataViewPage() {
         List<Person> personList = generatePersonItems();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewPage.java
@@ -43,6 +43,8 @@ public class ComboBoxListDataViewPage extends Div {
     public static final String SHOW_ITEM_DATA = "showItemData";
     public static final String SHOW_NEXT_DATA = "showNextData";
     public static final String SHOW_PREVIOUS_DATA = "showPreviousData";
+    public static final String SHOW_ITEM_COUNT = "showItemCount";
+    public static final String SHOW_ITEMS = "showItems";
     public static final String AGE_FILTER = "ageFilter";
     public static final String REMOVE_ITEM = "removeItem";
     public static final String REVERSE_SORTING = "reverseSorting";
@@ -92,6 +94,17 @@ public class ComboBoxListDataViewPage extends Div {
                 event -> itemData.setText("Item: " + dataView
                         .getItem(itemSelect.getValue()).getFirstName()));
         showItemData.setId(SHOW_ITEM_DATA);
+
+        NativeButton showItemCount = new NativeButton("Show Item Count",
+                click -> count
+                        .setText(String.valueOf(dataView.getItemCount())));
+        showItemCount.setId(SHOW_ITEM_COUNT);
+
+        NativeButton showItems = new NativeButton("Show Items",
+                click -> itemData
+                        .setText(dataView.getItems().map(Person::toString)
+                                .collect(Collectors.joining(","))));
+        showItems.setId(SHOW_ITEMS);
 
         // Navigation
         NativeButton showNextData = new NativeButton("Next person",
@@ -158,7 +171,8 @@ public class ComboBoxListDataViewPage extends Div {
 
         add(comboBox, itemSelect, filterByAge, reverseSorting,
                 selectItemOnIndex, showItemData, showNextData, showPreviousData,
-                removePerson, count, itemData, secondComboBox);
+                removePerson, count, itemData, showItemCount,
+                showItems, secondComboBox);
     }
 
     private List<Person> generatePersonItems() {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
@@ -31,6 +31,10 @@ import com.vaadin.flow.router.Route;
 @Route("vaadin-combo-box/filtering")
 public class FilteringPage extends Div {
 
+    static final String SWITCH_TO_UNKNOWN_ITEM_COUNT_BUTTON_ID = "switch-to-unknown-item-count";
+    static final String SWITCH_TO_IN_MEMORY_ITEMS_BUTTON_ID = "switch-to-in-memory-items";
+    static final String COMBOBOX_WITH_FILTERED_ITEMS_ID = "combo-box-with-filtered-items";
+
     private Div message = new Div();
 
     public FilteringPage() {
@@ -114,7 +118,7 @@ public class FilteringPage extends Div {
 
     private void createComboBoxWithMultiplePagesAndSourceSwitchers() {
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.setId("combo-box-with-filtered-items");
+        comboBox.setId(COMBOBOX_WITH_FILTERED_ITEMS_ID);
 
         List<String> items = LazyLoadingPage.generateStrings(500);
 
@@ -133,11 +137,11 @@ public class FilteringPage extends Div {
         NativeButton switchToUnknown = new NativeButton(
                 "Switch To Unknown Item Count",
                 click -> dataView.setItemCountUnknown());
-        switchToUnknown.setId("switch-to-unknown-item-count");
+        switchToUnknown.setId(SWITCH_TO_UNKNOWN_ITEM_COUNT_BUTTON_ID);
 
         NativeButton switchToInMemory = new NativeButton(
                 "Switch To In-memory Items", click -> comboBox.setItems(items));
-        switchToInMemory.setId("switch-to-in-memory-items");
+        switchToInMemory.setId(SWITCH_TO_IN_MEMORY_ITEMS_BUTTON_ID);
 
         add(new Div(), comboBox, switchToUnknown, switchToInMemory);
     }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
@@ -113,7 +113,6 @@ public class FilteringPage extends Div {
     }
 
     private void createComboBoxWithMultiplePagesAndSourceSwitchers() {
-        // addTitle("Callback data provider with custom page size 42");
         ComboBox<String> comboBox = new ComboBox<>();
         comboBox.setId("combo-box-with-filtered-items");
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
@@ -20,6 +20,7 @@ import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.ComboBox.ItemFilter;
+import com.vaadin.flow.component.combobox.dataview.ComboBoxLazyDataView;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -107,6 +108,39 @@ public class FilteringPage extends Div {
                 filter -> filter.isEmpty() ? 0 : 1);
         comboBoxWithEmptyFilterReturnsNone.setId("empty-filter-returns-none");
         add(new Div(), comboBoxWithEmptyFilterReturnsNone);
+
+        createComboBoxWithMultiplePagesAndSourceSwitchers();
+    }
+
+    private void createComboBoxWithMultiplePagesAndSourceSwitchers() {
+        // addTitle("Callback data provider with custom page size 42");
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("combo-box-with-filtered-items");
+
+        List<String> items = LazyLoadingPage.generateStrings(500);
+
+        ComboBoxLazyDataView<String> dataView = comboBox
+                .setItems(
+                        query -> items.stream()
+                                .filter(item -> item
+                                        .contains(query.getFilter().orElse("")))
+                                .skip(query.getOffset())
+                                .limit(query.getLimit()),
+                        query -> (int) items.stream()
+                                .filter(item -> item
+                                        .contains(query.getFilter().orElse("")))
+                                .count());
+
+        NativeButton switchToUnknown = new NativeButton(
+                "Switch To Unknown Item Count",
+                click -> dataView.setItemCountUnknown());
+        switchToUnknown.setId("switch-to-unknown-item-count");
+
+        NativeButton switchToInMemory = new NativeButton(
+                "Switch To In-memory Items", click -> comboBox.setItems(items));
+        switchToInMemory.setId("switch-to-in-memory-items");
+
+        add(new Div(), comboBox, switchToUnknown, switchToInMemory);
     }
 
 }

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.COMBO_BOX_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.GET_ITEMS_BUTTON_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.GET_ITEM_BUTTON_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.ITEMS_LIST_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.SWITCH_BUTTON_ID;
+
+@TestPath("combobox-lazy-data-view-page")
+public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
+
+    private ComboBoxElement comboBox;
+    private TestBenchElement itemsList;
+
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+        comboBox = $(ComboBoxElement.class).id(COMBO_BOX_ID);
+        itemsList = $("span").id(ITEMS_LIST_ID);
+    }
+
+    @Test
+    public void getItem_withDefinedItemCountAndClientSideFilter_returnsItemFromNotFilteredSet() {
+        comboBox.setFilter("777");
+
+        waitForItems(comboBox, items -> items.size() == 1
+                && "Item 777".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEM_BUTTON_ID);
+
+        Assert.assertEquals("The client filter shouldn't impact the items",
+                "Item 0", itemsList.getText());
+
+        comboBox.openPopup();
+
+        waitForItems(comboBox, items -> items.size() == 1000
+                && "Item 0".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEM_BUTTON_ID);
+
+        Assert.assertEquals("The client filter shouldn't impact the items",
+                "Item 0", itemsList.getText());
+    }
+
+    @Test
+    public void getItem_withUnknownItemCountAndClientSideFilter_returnsItemFromNotFilteredSet() {
+        clickButton(SWITCH_BUTTON_ID);
+        comboBox.setFilter("777");
+
+        waitForItems(comboBox, items -> items.size() == 1
+                && "Item 777".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEM_BUTTON_ID);
+
+        Assert.assertEquals("The client filter shouldn't impact the items",
+                "Item 0", itemsList.getText());
+
+        comboBox.openPopup();
+
+        waitForItems(comboBox, items -> items.size() == 200
+                && "Item 0".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEM_BUTTON_ID);
+
+        Assert.assertEquals("The client filter shouldn't impact the items",
+                "Item 0", itemsList.getText());
+    }
+
+    @Test
+    public void getItems_withUnknownItemCountAndClientSideFilter_returnsNotFilteredItems() {
+        clickButton(SWITCH_BUTTON_ID);
+        comboBox.setFilter("777");
+
+        waitForItems(comboBox, items -> items.size() == 1
+                && "Item 777".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEMS_BUTTON_ID);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                itemsList.getText().startsWith("Item 0,Item 1,Item 2")
+                        && itemsList.getText()
+                                .endsWith("Item 997,Item 998,Item 999"));
+
+        comboBox.openPopup();
+
+        waitForItems(comboBox, items -> items.size() == 200
+                && "Item 0".equals(getItemLabel(items, 0))
+                && "Item 49".equals(getItemLabel(items, 49)));
+
+        clickButton(GET_ITEMS_BUTTON_ID);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                itemsList.getText().startsWith("Item 0,Item 1,Item 2")
+                        && itemsList.getText()
+                        .endsWith("Item 997,Item 998,Item 999"));
+    }
+
+    @Test
+    public void getItems_withDefinedItemCountAndClientSideFilter_returnsNotFilteredItems() {
+        comboBox.setFilter("777");
+
+        waitForItems(comboBox,
+                items -> items.size() == 1
+                        && "Item 777".equals(getItemLabel(items, 0)));
+
+        clickButton(GET_ITEMS_BUTTON_ID);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                itemsList.getText().startsWith("Item 0,Item 1,Item 2")
+                        && itemsList.getText()
+                        .endsWith("Item 997,Item 998,Item 999"));
+
+        comboBox.openPopup();
+
+        waitForItems(comboBox,
+                items -> items.size() == 1000
+                        && "Item 0".equals(getItemLabel(items, 0))
+                        && "Item 49".equals(getItemLabel(items, 49)));
+
+        clickButton(GET_ITEMS_BUTTON_ID);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                itemsList.getText().startsWith("Item 0,Item 1,Item 2")
+                        && itemsList.getText()
+                        .endsWith("Item 997,Item 998,Item 999"));
+    }
+
+}

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxLazyDataViewIT.java
@@ -28,9 +28,9 @@ import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.C
 import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.GET_ITEMS_BUTTON_ID;
 import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.GET_ITEM_BUTTON_ID;
 import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.ITEMS_LIST_ID;
-import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.SWITCH_BUTTON_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxLazyDataViewPage.SWITCH_TO_UNKNOWN_COUNT_BUTTON_ID;
 
-@TestPath("combobox-lazy-data-view-page")
+@TestPath("vaadin-combo-box/combobox-lazy-data-view-page")
 public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
 
     private ComboBoxElement comboBox;
@@ -54,6 +54,11 @@ public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
 
         clickButton(GET_ITEM_BUTTON_ID);
 
+        // Checks the filter has been cleared after closing the drop down.
+        // ComboBox clears the cache after closing, so the item's values are
+        // not checked here
+        waitForItems(comboBox, items -> items.size() == 1000);
+
         Assert.assertEquals("The client filter shouldn't impact the items",
                 "Item 0", itemsList.getText());
 
@@ -70,13 +75,18 @@ public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
 
     @Test
     public void getItem_withUnknownItemCountAndClientSideFilter_returnsItemFromNotFilteredSet() {
-        clickButton(SWITCH_BUTTON_ID);
+        clickButton(SWITCH_TO_UNKNOWN_COUNT_BUTTON_ID);
         comboBox.setFilter("777");
 
         waitForItems(comboBox, items -> items.size() == 1
                 && "Item 777".equals(getItemLabel(items, 0)));
 
         clickButton(GET_ITEM_BUTTON_ID);
+
+        // Checks the filter has been cleared after closing the drop down
+        // ComboBox clears the cache after closing, so the item's values are
+        // not checked here
+        waitForItems(comboBox, items -> items.size() == 200);
 
         Assert.assertEquals("The client filter shouldn't impact the items",
                 "Item 0", itemsList.getText());
@@ -94,13 +104,18 @@ public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
 
     @Test
     public void getItems_withUnknownItemCountAndClientSideFilter_returnsNotFilteredItems() {
-        clickButton(SWITCH_BUTTON_ID);
+        clickButton(SWITCH_TO_UNKNOWN_COUNT_BUTTON_ID);
         comboBox.setFilter("777");
 
         waitForItems(comboBox, items -> items.size() == 1
                 && "Item 777".equals(getItemLabel(items, 0)));
 
         clickButton(GET_ITEMS_BUTTON_ID);
+
+        // Checks the filter has been cleared after closing the drop down
+        // ComboBox clears the cache after closing, so the item's values are
+        // not checked here
+        waitForItems(comboBox, items -> items.size() == 200);
 
         Assert.assertTrue("The client filter shouldn't impact the items",
                 itemsList.getText().startsWith("Item 0,Item 1,Item 2")
@@ -130,6 +145,11 @@ public class ComboBoxLazyDataViewIT extends AbstractComboBoxIT {
                         && "Item 777".equals(getItemLabel(items, 0)));
 
         clickButton(GET_ITEMS_BUTTON_ID);
+
+        // Checks the filter has been cleared after closing the drop down
+        // ComboBox clears the cache after closing, so the item's values are
+        // not checked here
+        waitForItems(comboBox, items -> items.size() == 1000);
 
         Assert.assertTrue("The client filter shouldn't impact the items",
                 itemsList.getText().startsWith("Item 0,Item 1,Item 2")

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
@@ -21,6 +21,7 @@ import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.F
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.ITEM_COUNT;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.ITEM_DATA;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.ITEM_SELECT;
+import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.NEW_PERSON_NAME;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.REMOVE_ITEM;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.REVERSE_SORTING;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SECOND_COMBO_BOX_ID;
@@ -156,9 +157,11 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
     @Test
     public void addItemCountChangeListener_newItemAdded_itemCountChanged() {
         // Add custom value
-        firstComboBox.sendKeys("Person NEW", Keys.ENTER);
+        firstComboBox.sendKeys(NEW_PERSON_NAME, Keys.ENTER);
         verifyNotifiedItemCount(
                 "Expected item count = 251 after adding a new item", 251);
+        // Erase input field's text, because it can be treated as a filter
+        firstComboBox.selectByText("");
 
         firstComboBox.openPopup();
         verifyNotifiedItemCount(
@@ -170,7 +173,7 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
                 251, getItems(secondComboBox).size());
 
         // Remove recently added item
-        selectItem(250);
+        firstComboBox.selectByText(NEW_PERSON_NAME);
         removeItem();
 
         firstComboBox.openPopup();

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
@@ -24,6 +24,8 @@ import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.I
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.REMOVE_ITEM;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.REVERSE_SORTING;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SECOND_COMBO_BOX_ID;
+import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SHOW_ITEMS;
+import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SHOW_ITEM_COUNT;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SHOW_ITEM_DATA;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SHOW_NEXT_DATA;
 import static com.vaadin.flow.component.combobox.test.ComboBoxListDataViewPage.SHOW_PREVIOUS_DATA;
@@ -195,6 +197,88 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
         assertItem(getItems(secondComboBox), 0, "Person 0 lastName");
     }
 
+    @Test
+    public void getItemCount_withClientSideFilter_returnsItemFromNotFilteredSet() {
+        firstComboBox.setFilter("222");
+
+        waitForItems(firstComboBox, items -> items.size() == 1
+                && "Person 222".equals(getItemLabel(items, 0)));
+
+        clickButton(SHOW_ITEM_COUNT);
+        Assert.assertEquals(
+                "The client filter shouldn't impact the item count", "250",
+                getItemCount());
+
+        firstComboBox.openPopup();
+
+        waitForItems(firstComboBox,
+                items -> items.size() == 250
+                        && "Person 0".equals(getItemLabel(items, 0))
+                        && "Person 49".equals(getItemLabel(items, 49)));
+
+        clickButton(SHOW_ITEM_COUNT);
+        Assert.assertEquals("The client filter shouldn't impact the item count",
+                "250", getItemCount());
+    }
+
+    @Test
+    public void getItem_withClientSideFilter_returnsItemFromNotFilteredSet() {
+        firstComboBox.setFilter("222");
+
+        waitForItems(firstComboBox, items -> items.size() == 1
+                && "Person 222".equals(getItemLabel(items, 0)));
+
+        selectItem(0);
+        showSelectedPerson();
+        verifySelectedPerson(0);
+
+        selectItem(249);
+        showSelectedPerson();
+        verifySelectedPerson(249);
+
+        firstComboBox.openPopup();
+
+        waitForItems(firstComboBox,
+                items -> items.size() == 250
+                        && "Person 0".equals(getItemLabel(items, 0))
+                        && "Person 49".equals(getItemLabel(items, 49)));
+
+        selectItem(0);
+        showSelectedPerson();
+        verifySelectedPerson(0);
+
+        selectItem(249);
+        showSelectedPerson();
+        verifySelectedPerson(249);
+    }
+
+    @Test
+    public void getItems_withClientSideFilter_returnsNotFilteredItems() {
+        firstComboBox.setFilter("222");
+
+        waitForItems(firstComboBox, items -> items.size() == 1
+                && "Person 222".equals(getItemLabel(items, 0)));
+
+        clickButton(SHOW_ITEMS);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                getItemData().startsWith("Person 0 lastName,Person 1 lastName")
+                        && getItemData().endsWith("Person 249 lastName"));
+
+        firstComboBox.openPopup();
+
+        waitForItems(firstComboBox,
+                items -> items.size() == 250
+                        && "Person 0".equals(getItemLabel(items, 0))
+                        && "Person 49".equals(getItemLabel(items, 49)));
+
+        clickButton(SHOW_ITEMS);
+
+        Assert.assertTrue("The client filter shouldn't impact the items",
+                getItemData().startsWith("Person 0 lastName,Person 1 lastName")
+                        && getItemData().endsWith("Person 249 lastName"));
+    }
+
     private void showSelectedPerson() {
         clickButton(SHOW_ITEM_DATA);
     }
@@ -217,7 +301,15 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
 
     private void verifySelectedPerson(int personIndex) {
         Assert.assertEquals("Item: Person " + personIndex,
-                $("span").id(ITEM_DATA).getText());
+                getItemData());
+    }
+
+    private String getItemData() {
+        return $("span").id(ITEM_DATA).getText();
+    }
+
+    private String getItemCount() {
+        return $("span").id(ITEM_COUNT).getText();
     }
 
     private void setTextFilter(ComboBoxElement comboBox, String filter) {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxListDataViewIT.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.testutil.TestPath;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
-@TestPath("combobox-list-data-view-page")
+@TestPath("vaadin-combo-box/combobox-list-data-view-page")
 public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
 
     private ComboBoxElement firstComboBox;
@@ -263,6 +263,11 @@ public class ComboBoxListDataViewIT extends AbstractComboBoxIT {
                 && "Person 222".equals(getItemLabel(items, 0)));
 
         clickButton(SHOW_ITEMS);
+
+        // Checks the filter has been cleared after closing the drop down
+        // ComboBox clears the cache after closing, so the item's values are
+        // not checked here
+        waitForItems(firstComboBox, items -> items.size() == 250);
 
         Assert.assertTrue("The client filter shouldn't impact the items",
                 getItemData().startsWith("Person 0 lastName,Person 1 lastName")

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
@@ -26,6 +26,10 @@ import org.openqa.selenium.By;
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
 
+import static com.vaadin.flow.component.combobox.test.FilteringPage.COMBOBOX_WITH_FILTERED_ITEMS_ID;
+import static com.vaadin.flow.component.combobox.test.FilteringPage.SWITCH_TO_IN_MEMORY_ITEMS_BUTTON_ID;
+import static com.vaadin.flow.component.combobox.test.FilteringPage.SWITCH_TO_UNKNOWN_ITEM_COUNT_BUTTON_ID;
+
 @TestPath("vaadin-combo-box/filtering")
 public class FilteringIT extends AbstractComboBoxIT {
 
@@ -40,7 +44,7 @@ public class FilteringIT extends AbstractComboBoxIT {
         box = $(ComboBoxElement.class).first();
 
         comboBoxWithFilteredItems = $(ComboBoxElement.class)
-                .id("combo-box-with-filtered-items");
+                .id(COMBOBOX_WITH_FILTERED_ITEMS_ID);
     }
 
     @Test
@@ -171,13 +175,13 @@ public class FilteringIT extends AbstractComboBoxIT {
 
     @Test
     public void unknownItemCountLazyLoadingFiltering_applyFilter_allPagesContainFilteredItems() {
-        clickButton("switch-to-unknown-item-count");
+        clickButton(SWITCH_TO_UNKNOWN_ITEM_COUNT_BUTTON_ID);
         verifyFilteredItems(comboBoxWithFilteredItems);
     }
 
     @Test
     public void inMemoryItemsFiltering_applyFilter_allPagesContainFilteredItems() {
-        clickButton("switch-to-in-memory-items");
+        clickButton(SWITCH_TO_IN_MEMORY_ITEMS_BUTTON_ID);
         verifyFilteredItems(comboBoxWithFilteredItems);
     }
 

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -876,7 +876,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                         convertOrNull.apply(getFilterString()), false);
 
         filterSlot = filter -> {
-            if (!Objects.equals(filter, lastFilter)) {
+            if (!Objects.equals(filter, lastFilter) ||
+                    // Since the data communicator erases the combo box
+                    // non-empty filter after each request, the filter needs
+                    // to be set again to data communicator even if the same
+                    // as last sent.
+                    !filter.isEmpty()) {
                 DataCommunicator.Filter<C> objectFilter =
                         new DataCommunicator.Filter<C>(
                                 convertOrNull.apply(filter), filter.isEmpty());

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -110,6 +110,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
     private static final String PROP_CLIENT_SIDE_FILTER = "_clientSideFilter";
+    private static final String PROP_OPENED = "opened";
 
     private static final String COUNT_QUERY_WITH_UNDEFINED_SIZE_ERROR_MESSAGE =
             "Trying to use exact size with a lazy loading component"
@@ -897,12 +898,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             // Register an opened listener to enable fetch and size queries to
             // data provider when the dropdown opens.
             lazyOpenRegistration = getElement().addPropertyChangeListener(
-                    "opened", this::executeRegistration);
+                    PROP_OPENED, this::executeRegistration);
         }
     }
 
     private void clearFilterOnClose(PropertyChangeEvent event) {
-        if (event.getValue().equals(Boolean.FALSE)) {
+        if (Boolean.FALSE.equals(event.getValue())) {
             if (lastFilter != null && !lastFilter.isEmpty()) {
                 clearClientSideFilterAndUpdateInMemoryFilter();
             }
@@ -918,7 +919,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      *            property change event for "open"
      */
     private void executeRegistration(PropertyChangeEvent event) {
-        if (event.getValue().equals(Boolean.TRUE)) {
+        if (Boolean.TRUE.equals(event.getValue())) {
             removeLazyOpenRegistration();
             dataCommunicator.setFetchEnabled(true);
         }
@@ -947,7 +948,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         }
 
         clearFilterOnCloseRegistration = getElement()
-                .addPropertyChangeListener("opened", this::clearFilterOnClose);
+                .addPropertyChangeListener(PROP_OPENED,
+                        this::clearFilterOnClose);
     }
 
     @Override

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxLazyDataViewTest.java
@@ -244,33 +244,6 @@ public class ComboBoxLazyDataViewTest {
     }
 
     @Test
-    public void getItems_withDefinedItemCountAndClientSideFilter_returnsNotFilteredItems() {
-        dataCommunicator.setRequestedRange(0, 50);
-        // Apply the client filter
-        filterSlot.accept(new DataCommunicator.Filter<>("ba", false));
-        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
-
-        // Verify the cached items data is updated in data communicator
-        Assert.assertEquals(2, dataCommunicator.getItemCount());
-        Assert.assertEquals("bar", dataCommunicator.getItem(0));
-        Assert.assertEquals("baz", dataCommunicator.getItem(1));
-
-        Stream<String> filteredItems = dataView.getItems();
-
-        // Check that the client filter does not affect the item handling API
-        // in data view
-        Assert.assertArrayEquals("The client filter shouldn't impact the items",
-                new String[] { "foo", "bar", "baz" }, filteredItems.toArray());
-
-        // Reset the client filter and check again
-        filterSlot.accept(new DataCommunicator.Filter<>("", true));
-        filteredItems = dataView.getItems();
-        Assert.assertArrayEquals(
-                "The client filter reset shouldn't impact the items",
-                new String[] { "foo", "bar", "baz" }, filteredItems.toArray());
-    }
-
-    @Test
     public void getItems_withUnknownItemCountAndNoClientSideFilter_returnsNotFilteredItems() {
         dataCommunicator.setDataProvider(undefinedItemCountDataProvider, "",
                 true);
@@ -283,48 +256,9 @@ public class ComboBoxLazyDataViewTest {
     }
 
     @Test
-    public void getItems_withUnknownItemCountAndClientSideFilter_returnsNotFilteredItems() {
-        filterSlot = dataCommunicator
-                .setDataProvider(undefinedItemCountDataProvider, "", true);
-        dataView.setItemCountUnknown();
-
-        dataCommunicator.setRequestedRange(0, 50);
-        // Apply the client filter
-        filterSlot.accept(new DataCommunicator.Filter<>("777", false));
-        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
-
-        // Verify the cached items data is updated in data communicator
-        Assert.assertEquals(1, dataCommunicator.getItemCount());
-        Assert.assertEquals("Item 777", dataCommunicator.getItem(0));
-
-        List<String> items = dataView.getItems().collect(Collectors.toList());
-
-        // Check that the client filter does not affect the item handling API
-        // in data view
-        Assert.assertEquals(1000, items.size());
-        Assert.assertEquals("Item 0", items.get(0));
-        Assert.assertEquals("Item 999", items.get(items.size() - 1));
-
-        // Reset the client filter and check again
-        filterSlot.accept(new DataCommunicator.Filter<>("", true));
-        items = dataView.getItems().collect(Collectors.toList());
-        Assert.assertEquals(1000, items.size());
-        Assert.assertEquals("Item 0", items.get(0));
-        Assert.assertEquals("Item 999", items.get(items.size() - 1));
-    }
-
-    @Test
     public void getItem_withDefinedItemCountAndNoClientSideFilter_returnsItemFromNotFilteredSet() {
         Assert.assertEquals("Invalid item on index 1", "bar",
                 dataView.getItem(1));
-    }
-
-    @Test
-    public void getItem_withDefinedItemCountAndClientSideFilter_returnsItemFromNotFilteredSet() {
-        filterSlot.accept(new DataCommunicator.Filter<>("bar", false));
-        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
-        Assert.assertEquals("Invalid item on index 0", "foo",
-                dataView.getItem(0));
     }
 
     @Test
@@ -335,18 +269,6 @@ public class ComboBoxLazyDataViewTest {
 
         Assert.assertEquals("Invalid item on index 777", "Item 777",
                 dataView.getItem(777));
-    }
-
-    @Test
-    public void getItem_withUnknownItemCountAndClientSideFilter_returnsItemFromNotFilteredSet() {
-        filterSlot = dataCommunicator
-                .setDataProvider(undefinedItemCountDataProvider, "", true);
-        dataView.setItemCountUnknown();
-
-        filterSlot.accept(new DataCommunicator.Filter<>("777", false));
-        ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
-        Assert.assertEquals("Invalid item on index 0", "Item 0",
-                dataView.getItem(0));
     }
 
     @Test

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/dataview/ComboBoxListDataViewTest.java
@@ -62,6 +62,8 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         dataView = component.setItems(items);
 
         ComboBoxDataViewTestHelper.setClientSideFilter(component, "ba");
+        // Close combo box drop down to trigger the filter erase
+        component.setOpened(false);
         ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
 
         Stream<String> filteredItems = dataView.getItems();
@@ -96,6 +98,8 @@ public class ComboBoxListDataViewTest extends AbstractListDataViewListenerTest {
         dataView = component.setItems(items);
 
         ComboBoxDataViewTestHelper.setClientSideFilter(component, "ba");
+        // Close combo box drop down to trigger the filter erase
+        component.setOpened(false);
         ComboBoxDataViewTestHelper.fakeClientCommunication(ui);
 
         int itemCount = dataView.getItemCount();


### PR DESCRIPTION
Since the DataCommunicator erases the combo box non-empty filter after each request, the filter needs to be set again to DataCommunicator even if it's the same as last sent.

Fixes: https://github.com/vaadin/vaadin-flow-components/issues/388