### PR TITLE
chore: Update profile name for resource packaging

### DIFF
--- a/scripts/templates/pom-demo.xml
+++ b/scripts/templates/pom-demo.xml
@@ -34,9 +34,11 @@
 
     <profiles>
         <profile>
-            <id>default</id>
+            <id>jar</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!war</name>
+                </property>
             </activation>
             <properties>
                 <packaging.type>jar</packaging.type>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-demo/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-demo/pom.xml
@@ -93,9 +93,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-demo/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-demo/pom.xml
@@ -66,9 +66,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow-demo/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow-demo/pom.xml
@@ -57,9 +57,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-board-flow-parent/vaadin-board-flow-demo/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-demo/pom.xml
@@ -53,9 +53,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-button-flow-parent/vaadin-button-flow-demo/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-demo/pom.xml
@@ -67,9 +67,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
@@ -64,9 +64,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-demo/pom.xml
@@ -73,9 +73,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-demo/pom.xml
@@ -78,9 +78,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-demo/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-demo/pom.xml
@@ -63,9 +63,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-demo/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-demo/pom.xml
@@ -63,9 +63,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-demo/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-demo/pom.xml
@@ -58,9 +58,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-demo/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-demo/pom.xml
@@ -63,9 +63,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-demo/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-demo/pom.xml
@@ -74,9 +74,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-demo/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-demo/pom.xml
@@ -62,9 +62,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-demo/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-demo/pom.xml
@@ -62,9 +62,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-details-flow-parent/vaadin-details-flow-demo/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-demo/pom.xml
@@ -57,9 +57,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-demo/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-demo/pom.xml
@@ -62,9 +62,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-demo/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-demo/pom.xml
@@ -77,9 +77,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-demo/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-demo/pom.xml
@@ -109,9 +109,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/pom.xml
@@ -53,9 +53,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-demo/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-demo/pom.xml
@@ -49,9 +49,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-demo/pom.xml
@@ -59,9 +59,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-demo/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-demo/pom.xml
@@ -72,9 +72,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-login-flow-parent/vaadin-login-flow-demo/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-demo/pom.xml
@@ -72,9 +72,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-demo/pom.xml
@@ -67,9 +67,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-demo/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-demo/pom.xml
@@ -68,9 +68,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-demo/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-demo/pom.xml
@@ -57,9 +57,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-demo/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-demo/pom.xml
@@ -47,9 +47,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-demo/pom.xml
@@ -68,9 +68,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-demo/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-demo/pom.xml
@@ -58,9 +58,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-select-flow-parent/vaadin-select-flow-demo/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-demo/pom.xml
@@ -77,9 +77,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-demo/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-demo/pom.xml
@@ -47,9 +47,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-demo/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-demo/pom.xml
@@ -67,9 +67,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-demo/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-demo/pom.xml
@@ -67,9 +67,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-demo/pom.xml
@@ -62,9 +62,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-demo/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-demo/pom.xml
@@ -57,9 +57,11 @@
   </build>
   <profiles>
     <profile>
-      <id>default</id>
+      <id>jar</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!war</name>
+        </property>
       </activation>
       <properties>
         <packaging.type>jar</packaging.type>


### PR DESCRIPTION
be aware of this maven profile behavior: This profile will automatically be active for all builds unless another profile in the same POM is activated using -P or conditions.

for this fix, we found that:
in order to build OSGi manifest, we need to active the attach-docs profile, then it will de-active the default profile in demo module, which will cause the build test failure.