### PR TITLE
chore: fix error when deploying OSGi MF

### DIFF
--- a/scripts/templates/pom-flow-pro.xml
+++ b/scripts/templates/pom-flow-pro.xml
@@ -79,6 +79,15 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>parse-version</id>
+                                <goals>
+                                    <goal>parse-version</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/scripts/updateJavaPOMs.js
+++ b/scripts/updateJavaPOMs.js
@@ -86,19 +86,6 @@ async function consolidatePomParent() {
   });
 }
 
-async function removePlugin(pom, pluginId){
-  const pomJs = await xml2js.parseStringPromise(fs.readFileSync(pom, 'utf8'));
-  if(pomJs.project.profiles[0].profile[2].build[0].plugins[0].plugin){
-  }
-
-  pomJs.project.profiles[0].profile[2].build[0].plugins[0].plugin=
-  pomJs.project.profiles[0].profile[2].build[0].plugins[0].plugin.filter(plugin => !(plugin.artifactId== pluginId))
-
-  const xml = new xml2js.Builder().buildObject(pomJs);
-  console.log(`Update ${pom}`);
-  fs.writeFileSync(pom, xml + '\n', 'utf8');
-}
-
 async function consolidatePomFlow() {
   const template = proComponents.includes(componentName) ? 'pom-flow-pro.xml' : 'pom-flow.xml';
   consolidate(template, `${mod}/${name}-flow/pom.xml`);
@@ -108,10 +95,6 @@ async function consolidatePomTB() {
 }
 async function consolidatePomDemo() {
   await consolidate('pom-demo.xml', `${mod}/${name}-flow-demo/pom.xml`)
-  // Remove the unnecessary plugin from vaadin-charts-flow-demo module
-  if(`${mod}` == 'vaadin-charts-flow-parent'){
-    removePlugin(`${mod}/${name}-flow-demo/pom.xml`, 'maven-bundle-plugin')
-  }
 }
 async function consolidatePomIT() {
   consolidate('pom-integration-tests.xml', `${mod}/${name}-flow-integration-tests/pom.xml`);

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -105,6 +105,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-demo/pom.xml
@@ -112,6 +112,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
           </plugin>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -103,6 +103,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -104,6 +104,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
@@ -101,6 +101,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -121,6 +121,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -132,6 +132,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -124,6 +124,15 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>parse-version</id>
+                <goals>
+                  <goal>parse-version</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
add the missing execution part for build-helper-maven-plugin in pro components
remove the charts exclusion from the pom update script