### PR TITLE
chore: Remove the redundant version from V14.5

### DIFF
--- a/scripts/templates/pom-bower-mode.xml
+++ b/scripts/templates/pom-bower-mode.xml
@@ -58,10 +58,6 @@
             </configuration>
         </plugin>
         <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>properties-maven-plugin</artifactId>
-        </plugin>
-        <plugin>
             <artifactId>maven-install-plugin</artifactId>
             <configuration>
                 <skip>true</skip>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-accordion-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.accordion.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Accordion Integration Tests in Bower Mode</name>
   <properties>
@@ -23,25 +22,25 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-accordion-testbench</artifactId>
-      <version>${vaadin.accordion.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-testbench</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-testbench</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-accordion-flow</artifactId>
-      <version>${vaadin.accordion.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -62,12 +61,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -76,7 +75,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -114,10 +113,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-app-layout-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.app.layout.version}</version>
   <packaging>war</packaging>
   <name>Vaadin App Layout Integration Tests in Bower Mode</name>
   <properties>
@@ -49,32 +48,32 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-flow</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-notification-flow</artifactId>
-      <version>${vaadin.notification.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-app-layout-flow</artifactId>
-      <version>${vaadin.app.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -85,13 +84,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-app-layout-testbench</artifactId>
-      <version>${vaadin.app.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,10 +128,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-board-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.board.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Board Integration Tests in Bower Mode</name>
   <properties>
@@ -34,7 +33,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-board-flow</artifactId>
-      <version>${vaadin.board.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -45,7 +44,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-board-testbench</artifactId>
-      <version>${vaadin.board.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -57,7 +56,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -95,10 +94,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-button-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.button.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Button Integration Tests in Bower Mode</name>
   <properties>
@@ -23,13 +22,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-testbench</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -58,7 +57,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow-demo</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -68,7 +67,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -106,10 +105,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-charts-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.charts.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Charts Integration Tests in Bower Mode</name>
   <properties>
@@ -18,7 +17,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-charts-flow-demo</artifactId>
-      <version>${vaadin.charts.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -33,19 +32,19 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-charts-testbench</artifactId>
-      <version>${vaadin.charts.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-testbench</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-testbench</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -57,7 +56,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -95,10 +94,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-checkbox-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.checkbox.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Checkbox Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-flow</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-flow-demo</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -53,13 +52,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-testbench</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -97,10 +96,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-combo-box-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.combo.box.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Combo Box Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow-demo</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -53,19 +52,19 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-testbench</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-testbench</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,10 +102,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-confirm-dialog-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.confirm.dialog.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Confirm Dialog Integration Tests in Bower Mode</name>
   <properties>
@@ -44,22 +43,22 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-flow</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-confirm-dialog-flow</artifactId>
-      <version>${vaadin.confirm.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -70,13 +69,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-confirm-dialog-testbench</artifactId>
-      <version>${vaadin.confirm.dialog.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -114,10 +113,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-context-menu-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.context.menu.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Context Menu Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-context-menu-flow</artifactId>
-      <version>${vaadin.context.menu.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-context-menu-flow-demo</artifactId>
-      <version>${vaadin.context.menu.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -53,7 +52,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-context-menu-testbench</artifactId>
-      <version>${vaadin.context.menu.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,10 +102,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-cookie-consent-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.cookie.consent.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Cookie Consent Integration Tests in Bower Mode</name>
   <properties>
@@ -35,12 +34,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-cookie-consent-flow</artifactId>
-      <version>${vaadin.cookie.consent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-cookie-consent-testbench</artifactId>
-      <version>${vaadin.cookie.consent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -50,7 +49,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -88,10 +87,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-crud-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.crud.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Crud Integration Tests in Bower Mode</name>
   <properties>
@@ -23,31 +22,31 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-crud-testbench</artifactId>
-      <version>${vaadin.crud.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-confirm-dialog-testbench</artifactId>
-      <version>${vaadin.confirm.dialog.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-testbench</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-testbench</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-crud-flow</artifactId>
-      <version>${vaadin.crud.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -68,37 +67,37 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-flow</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-form-layout-flow</artifactId>
-      <version>${vaadin.form.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -108,7 +107,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -146,10 +145,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-custom-field-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.custom.field.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Custom Field Integration Tests in Bower Mode</name>
   <properties>
@@ -24,19 +23,19 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-custom-field-testbench</artifactId>
-      <version>${vaadin.custom.field.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-testbench</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-custom-field-flow</artifactId>
-      <version>${vaadin.custom.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -53,7 +52,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -67,7 +66,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -105,10 +104,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-date-picker-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.date.picker.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Date Picker Integration Tests in Bower Mode</name>
   <properties>
@@ -30,17 +29,17 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-picker-flow</artifactId>
-      <version>${vaadin.date.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-picker-flow-demo</artifactId>
-      <version>${vaadin.date.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-flow</artifactId>
-      <version>${vaadin.grid.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -63,13 +62,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-picker-testbench</artifactId>
-      <version>${vaadin.date.picker.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -107,10 +106,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-date-time-picker-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.date.time.picker.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Date Time Picker Integration Tests in Bower Mode</name>
   <properties>
@@ -30,27 +29,27 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-time-picker-flow</artifactId>
-      <version>${vaadin.date.time.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-time-picker-flow-demo</artifactId>
-      <version>${vaadin.date.time.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-custom-field-flow</artifactId>
-      <version>${vaadin.custom.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -69,13 +68,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-date-time-picker-testbench</artifactId>
-      <version>${vaadin.date.time.picker.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -113,10 +112,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-details-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.details.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Details Integration Tests in Bower Mode</name>
   <properties>
@@ -24,13 +23,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-details-testbench</artifactId>
-      <version>${vaadin.details.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-details-flow</artifactId>
-      <version>${vaadin.details.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -60,7 +59,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -98,10 +97,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-dialog-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.dialog.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Dialog Integration Tests in Bower Mode</name>
   <properties>
@@ -30,7 +29,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-flow</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -39,7 +38,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -48,12 +47,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -66,7 +65,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-testbench</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -83,7 +82,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -121,10 +120,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-form-layout-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.form.layout.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Form Layout Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-form-layout-flow</artifactId>
-      <version>${vaadin.form.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-form-layout-flow-demo</artifactId>
-      <version>${vaadin.form.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -53,13 +52,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-form-layout-testbench</artifactId>
-      <version>${vaadin.form.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -97,10 +96,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-grid-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.grid.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Grid Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-flow</artifactId>
-      <version>${vaadin.grid.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-flow-demo</artifactId>
-      <version>${vaadin.grid.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -48,32 +47,32 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-context-menu-flow</artifactId>
-      <version>${vaadin.context.menu.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-flow</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-flow</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -97,13 +96,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-testbench</artifactId>
-      <version>${vaadin.grid.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -141,10 +140,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-grid-pro-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.grid.pro.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Grid Pro Integration Tests in Bower Mode</name>
   <properties>
@@ -23,33 +22,33 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-pro-testbench</artifactId>
-      <version>${vaadin.grid.pro.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-grid-pro-flow</artifactId>
-      <version>${vaadin.grid.pro.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-combo-box-flow</artifactId>
-      <version>${vaadin.combo.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -79,7 +78,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -117,10 +116,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-icons-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.icons.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Icons Integration Tests in Bower Mode</name>
   <properties>
@@ -23,13 +22,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-testbench</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -51,12 +50,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -94,10 +93,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-iron-list-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.iron.list.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Iron List Integration Tests in Bower Mode</name>
   <properties>
@@ -38,12 +37,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-iron-list-flow</artifactId>
-      <version>${vaadin.iron.list.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-iron-list-flow-demo</artifactId>
-      <version>${vaadin.iron.list.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -56,13 +55,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-iron-list-testbench</artifactId>
-      <version>${vaadin.iron.list.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -100,10 +99,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-list-box-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.list.box.version}</version>
   <packaging>war</packaging>
   <name>Vaadin List Box Integration Tests in Bower Mode</name>
   <properties>
@@ -23,12 +22,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-list-box-testbench</artifactId>
-      <version>${vaadin.list.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-list-box-flow</artifactId>
-      <version>${vaadin.list.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -63,7 +62,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-list-box-flow-demo</artifactId>
-      <version>${vaadin.list.box.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -73,7 +72,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -111,10 +110,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-login-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.login.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Login Integration Tests in Bower Mode</name>
   <properties>
@@ -24,13 +23,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-login-testbench</artifactId>
-      <version>${vaadin.login.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-login-flow</artifactId>
-      <version>${vaadin.login.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -55,7 +54,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,10 +102,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-menu-bar-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.menu.bar.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Menu Bar Integration Tests in Bower Mode</name>
   <properties>
@@ -23,13 +22,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-menu-bar-testbench</artifactId>
-      <version>${vaadin.menu.bar.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-menu-bar-flow</artifactId>
-      <version>${vaadin.menu.bar.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -58,7 +57,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-menu-bar-flow-demo</artifactId>
-      <version>${vaadin.menu.bar.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -68,7 +67,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -106,10 +105,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-notification-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.notification.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Notification Integration Tests in Bower Mode</name>
   <properties>
@@ -23,13 +22,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-notification-testbench</artifactId>
-      <version>${vaadin.notification.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-notification-flow</artifactId>
-      <version>${vaadin.notification.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -58,7 +57,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-notification-flow-demo</artifactId>
-      <version>${vaadin.notification.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -68,7 +67,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -106,10 +105,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-ordered-layout-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.ordered.layout.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Ordered Layout Integration Tests in Bower Mode</name>
   <properties>
@@ -23,12 +22,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-testbench</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -48,7 +47,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow-demo</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -58,13 +57,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-testbench</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -102,10 +101,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-progress-bar-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.progress.bar.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Progress Bar Integration Tests in Bower Mode</name>
   <properties>
@@ -23,12 +22,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-progress-bar-testbench</artifactId>
-      <version>${vaadin.progress.bar.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-progress-bar-flow</artifactId>
-      <version>${vaadin.progress.bar.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -48,7 +47,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-progress-bar-flow-demo</artifactId>
-      <version>${vaadin.progress.bar.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -58,7 +57,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -96,10 +95,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-radio-button-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.radio.button.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Radio Button Integration Tests in Bower Mode</name>
   <properties>
@@ -28,17 +27,17 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-flow</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-flow-demo</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-testbench</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -73,7 +72,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-testbench</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -83,7 +82,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -121,10 +120,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-rich-text-editor-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.rich.text.editor.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Rich Text Editor Integration Tests in Bower Mode</name>
   <properties>
@@ -28,19 +27,19 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-rich-text-editor-testbench</artifactId>
-      <version>${vaadin.rich.text.editor.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-testbench</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-rich-text-editor-flow</artifactId>
-      <version>${vaadin.rich.text.editor.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -61,27 +60,27 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
-      <version>${vaadin.button.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dialog-flow</artifactId>
-      <version>${vaadin.dialog.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-notification-flow</artifactId>
-      <version>${vaadin.notification.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-icons-flow</artifactId>
-      <version>${vaadin.icons.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${vaadin.ordered.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -90,7 +89,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -128,10 +127,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-select-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.select.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Select Integration Tests in Bower Mode</name>
   <properties>
@@ -24,19 +23,19 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-select-testbench</artifactId>
-      <version>${vaadin.select.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-testbench</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-select-flow</artifactId>
-      <version>${vaadin.select.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -66,7 +65,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-checkbox-flow</artifactId>
-      <version>${vaadin.checkbox.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -77,7 +76,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -115,10 +114,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-split-layout-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.split.layout.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Split Layout Integration Tests in Bower Mode</name>
   <properties>
@@ -23,7 +22,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-split-layout-testbench</artifactId>
-      <version>${vaadin.split.layout.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -35,7 +34,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-split-layout-flow</artifactId>
-      <version>${vaadin.split.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -55,7 +54,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-split-layout-flow-demo</artifactId>
-      <version>${vaadin.split.layout.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -103,10 +102,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-tabs-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.tabs.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Tabs Integration Tests in Bower Mode</name>
   <properties>
@@ -18,12 +17,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-tabs-flow</artifactId>
-      <version>${vaadin.tabs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-tabs-flow-demo</artifactId>
-      <version>${vaadin.tabs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -33,7 +32,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-tabs-testbench</artifactId>
-      <version>${vaadin.tabs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -58,7 +57,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -96,10 +95,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-text-field-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.text.field.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Text Field Integration Tests in Bower Mode</name>
   <properties>
@@ -23,13 +22,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-testbench</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-radio-button-testbench</artifactId>
-      <version>${vaadin.radio.button.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -60,7 +59,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -73,12 +72,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-text-field-flow-demo</artifactId>
-      <version>${vaadin.text.field.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -116,10 +115,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-time-picker-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.time.picker.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Time Picker Integration Tests in Bower Mode</name>
   <properties>
@@ -30,12 +29,12 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-time-picker-flow</artifactId>
-      <version>${vaadin.time.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-time-picker-flow-demo</artifactId>
-      <version>${vaadin.time.picker.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -54,13 +53,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-time-picker-testbench</artifactId>
-      <version>${vaadin.time.picker.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -98,10 +97,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/pom-bower-mode.xml
@@ -7,7 +7,6 @@
     <version>14.5-SNAPSHOT</version>
   </parent>
   <artifactId>vaadin-upload-integration-tests-bower-mode</artifactId>
-  <version>${vaadin.upload.version}</version>
   <packaging>war</packaging>
   <name>Vaadin Upload Integration Tests in Bower Mode</name>
   <properties>
@@ -24,13 +23,13 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${vaadin.upload.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-upload-flow</artifactId>
-      <version>${vaadin.upload.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -71,7 +70,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-flow-components-shared</artifactId>
-      <version>${vaadin.flow.components.shared.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -109,10 +108,6 @@
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
clean the pom for the duplicated plugin declaration 