### PR TITLE
CP 17.0: FileBuffer getInputStream is closed (#405)

### DIFF
--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/it/FileBufferView.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/main/java/com/vaadin/flow/component/upload/tests/it/FileBufferView.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload.tests.it;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.upload.SucceededEvent;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.FileBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileBuffer;
+import com.vaadin.flow.router.Route;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Function;
+
+/**
+ * View for {@link Upload} tests using {@link FileBuffer} and {@link MultiFileBuffer}.
+ *
+ * @author Vaadin Ltd
+ */
+@Route("vaadin-upload/filebuffer")
+public class FileBufferView extends Div {
+    public FileBufferView() {
+        add(createSingleFileUpload());
+        add(createMultiFileUpload());
+    }
+
+    private static Div createSingleFileUpload() {
+        final FileBuffer buffer = new FileBuffer();
+        final Upload singleFileUpload = new Upload(buffer);
+        singleFileUpload.setId("single-upload");
+        singleFileUpload.setMaxFiles(1);
+        return setupUploadSection(singleFileUpload,
+            e -> buffer.getInputStream());
+
+    }
+
+    private static Div createMultiFileUpload() {
+        final MultiFileBuffer buffer = new MultiFileBuffer();
+        final Upload multiFileUpload = new Upload(buffer);
+        multiFileUpload.setId("multi-upload");
+        return setupUploadSection(multiFileUpload,
+            e -> buffer.getInputStream(e.getFileName()));
+    }
+
+    private static Div setupUploadSection(Upload upload,
+        Function<SucceededEvent, InputStream> streamProvider) {
+        final String uploadId = upload.getId().orElse("");
+        final Div output = new Div();
+        output.setId(uploadId + "-output");
+        final Div eventsOutput = new Div();
+        eventsOutput.setId(uploadId + "-event-output");
+
+        upload.addSucceededListener(event -> {
+            try {
+                output.add(event.getFileName());
+                output.add(
+                    IOUtils.toString(streamProvider.apply(event), "UTF-8"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            eventsOutput.add("-succeeded");
+        });
+
+        upload.addAllFinishedListener(event -> eventsOutput.add("-finished"));
+
+        return new Div(output, eventsOutput, upload);
+    }
+
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/AbstractUploadIT.java
@@ -1,0 +1,62 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.tests.AbstractComponentIT;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public abstract class AbstractUploadIT extends AbstractComponentIT {
+    /**
+     * @return The generated temp file handle
+     * @throws IOException
+     */
+    File createTempFile() throws IOException {
+        File tempFile = File.createTempFile("TestFileUpload", ".txt");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
+        writer.write(getTempFileContents());
+        writer.close();
+        tempFile.deleteOnExit();
+        return tempFile;
+    }
+
+    String getTempFileContents() {
+        return "This is a test file! Row 2 Row3";
+    }
+
+    void fillPathToUploadInput(WebElement input, String... tempFileNames)
+        throws Exception {
+        // create a valid path in upload input element. Instead of selecting a
+        // file by some file browsing dialog, we use the local path directly.
+        setLocalFileDetector(input);
+        input.sendKeys(String.join(System.lineSeparator(), tempFileNames));
+    }
+
+    private void setLocalFileDetector(WebElement element) throws Exception {
+        if (getRunLocallyBrowser() != null) {
+            return;
+        }
+
+        if (element instanceof WrapsElement) {
+            element = ((WrapsElement) element).getWrappedElement();
+        }
+        if (element instanceof RemoteWebElement) {
+            ((RemoteWebElement) element)
+                .setFileDetector(new LocalFileDetector());
+        } else {
+            throw new IllegalArgumentException(
+                "Expected argument of type RemoteWebElement, received "
+                    + element.getClass().getName());
+        }
+    }
+
+    WebElement getInput(WebElement upload) {
+        return getInShadowRoot(upload, By.id("fileInput"));
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferIT.java
@@ -1,0 +1,62 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.upload.testbench.UploadElement;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+
+/**
+ * Tests for Upload using FileBuffer and MultiFileBuffer.
+ */
+@TestPath("vaadin-upload/filebuffer")
+public class FileBufferIT extends AbstractUploadIT {
+    @Test
+    public void testUploadAnyFile() throws Exception {
+        open();
+        final UploadElement upload = $(UploadElement.class).id("single-upload");
+        waitUntil(driver -> upload.isDisplayed());
+
+        File tempFile = createTempFile();
+        fillPathToUploadInput(getInput(upload),tempFile.getPath());
+
+        WebElement uploadOutput = getDriver().findElement(By.id("single-upload-output"));
+
+        String content = uploadOutput.getText();
+
+        String expectedContent = tempFile.getName() + getTempFileContents();
+
+        Assert.assertEquals("Upload content does not match expected",
+            expectedContent, content);
+    }
+
+    @Test
+    public void testUploadMultipleEventOrder() throws Exception {
+        if (getRunLocallyBrowser() == null) {
+            // Multiple file upload does not work with Remotewebdriver
+            // https://github.com/SeleniumHQ/selenium/issues/7408
+            throw new AssumptionViolatedException(
+                "Skipped <Multiple file upload does not work with Remotewebdriver>");
+        }
+        open();
+
+        final UploadElement upload = $(UploadElement.class).id("multi-upload");
+        waitUntil(driver -> upload.isDisplayed());
+
+        File tempFile = createTempFile();
+
+        fillPathToUploadInput(getInput(upload),tempFile.getPath(), tempFile.getPath(),
+            tempFile.getPath());
+
+        WebElement eventsOutput = getDriver()
+            .findElement(By.id("multi-upload-event-output"));
+
+        Assert.assertEquals("Upload event order does not match expected",
+            "-succeeded-succeeded-succeeded-finished",
+            eventsOutput.getText());
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java
@@ -15,10 +15,7 @@
  */
 package com.vaadin.flow.component.upload.tests;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -28,12 +25,8 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.internal.WrapsElement;
 import org.openqa.selenium.logging.LogEntry;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebElement;
 
-import com.vaadin.tests.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
 import static org.junit.Assert.assertThat;
@@ -42,7 +35,7 @@ import static org.junit.Assert.assertThat;
  * Upload component test class.
  */
 @TestPath("vaadin-upload")
-public class UploadIT extends AbstractComponentIT {
+public class UploadIT extends AbstractUploadIT {
 
     @Test
     public void testUploadAnyFile() throws Exception {
@@ -135,30 +128,10 @@ public class UploadIT extends AbstractComponentIT {
         Assert.assertEquals("Перетащите файл сюда...", dropLabel.getText());
     }
 
-    /**
-     * @return The generated temp file handle
-     * @throws IOException
-     */
-    private File createTempFile() throws IOException {
-        File tempFile = File.createTempFile("TestFileUpload", ".txt");
-        BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
-        writer.write(getTempFileContents());
-        writer.close();
-        tempFile.deleteOnExit();
-        return tempFile;
-    }
-
-    private String getTempFileContents() {
-        return "This is a test file! Row 2 Row3";
-    }
 
     private void fillPathToUploadInput(String... tempFileNames)
             throws Exception {
-        // create a valid path in upload input element. Instead of selecting a
-        // file by some file browsing dialog, we use the local path directly.
-        WebElement input = getInput();
-        setLocalFileDetector(input);
-        input.sendKeys(String.join(System.lineSeparator(), tempFileNames));
+        fillPathToUploadInput(getInput(),tempFileNames);
     }
 
     private WebElement getUpload() {
@@ -172,24 +145,8 @@ public class UploadIT extends AbstractComponentIT {
      * @return actual upload button
      */
     private WebElement getInput() {
-        return getInShadowRoot(getUpload(), By.id("fileInput"));
+        return getInput(getUpload());
     }
 
-    private void setLocalFileDetector(WebElement element) throws Exception {
-        if (getRunLocallyBrowser() != null) {
-            return;
-        }
 
-        if (element instanceof WrapsElement) {
-            element = ((WrapsElement) element).getWrappedElement();
-        }
-        if (element instanceof RemoteWebElement) {
-            ((RemoteWebElement) element)
-                    .setFileDetector(new LocalFileDetector());
-        } else {
-            throw new IllegalArgumentException(
-                    "Expected argument of type RemoteWebElement, received "
-                            + element.getClass().getName());
-        }
-    }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/AbstractFileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/AbstractFileBuffer.java
@@ -62,7 +62,7 @@ public abstract class AbstractFileBuffer implements Serializable {
      */
     protected FileOutputStream createFileOutputStream(String fileName) {
         try {
-            return new FileOutputStream(factory.createFile(fileName));
+            return new UploadOutputStream(factory.createFile(fileName));
         } catch (IOException e) {
             getLogger().log(Level.SEVERE,
                     "Failed to create file output stream for: '" + fileName

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileBuffer.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.upload.receivers;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -89,9 +90,9 @@ public class FileBuffer extends AbstractFileBuffer implements Receiver {
      */
     public InputStream getInputStream() {
         if (file != null) {
+            final File path = file.getFile();
             try {
-                return new FileInputStream(
-                        ((FileOutputStream) file.getOutputBuffer()).getFD());
+                return new FileInputStream(path);
             } catch (IOException e) {
                 getLogger().log(Level.WARNING,
                         "Failed to create InputStream for: '" + getFileName()

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileData.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/FileData.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.upload.receivers;
 
+import java.io.File;
 import java.io.OutputStream;
 import java.io.Serializable;
 
@@ -64,5 +65,24 @@ public class FileData implements Serializable {
      */
     public OutputStream getOutputBuffer() {
         return outputBuffer;
+    }
+
+    /**
+     *
+     * @return Temporary file containing the uploaded data.
+     * @throws NullPointerException if outputBuffer is null
+     * @throws UnsupportedOperationException if outputBuffer is not an {@link UploadOutputStream}
+     */
+    File getFile() {
+        if (outputBuffer == null) {
+            throw new NullPointerException("OutputBuffer is null");
+        }
+        if (outputBuffer instanceof UploadOutputStream) {
+            return ((UploadOutputStream) outputBuffer).getFile();
+        }
+        final String MESSAGE = String
+            .format("%s not supported. Use a UploadOutputStream",
+                outputBuffer.getClass());
+        throw new UnsupportedOperationException(MESSAGE);
     }
 }

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/MultiFileBuffer.java
@@ -102,9 +102,7 @@ public class MultiFileBuffer extends AbstractFileBuffer
     public InputStream getInputStream(String fileName) {
         if (files.containsKey(fileName)) {
             try {
-                return new FileInputStream(
-                        ((FileOutputStream) files.get(fileName)
-                                .getOutputBuffer()).getFD());
+                return new FileInputStream(files.get(fileName).getFile());
             } catch (IOException e) {
                 getLogger().log(Level.WARNING,
                         "Failed to create InputStream for: '" + fileName + "'",

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/UploadOutputStream.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/receivers/UploadOutputStream.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.upload.receivers;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.Serializable;
+
+/**
+ * FileOutputStream with a reference to the output file.
+ */
+class UploadOutputStream extends FileOutputStream implements
+    Serializable {
+    private final File file;
+
+    /**
+     * @see FileOutputStream#FileOutputStream(File)
+     * @param file File to write.
+     * @throws FileNotFoundException see {@link FileOutputStream#FileOutputStream(File)}
+     */
+    UploadOutputStream(File file) throws FileNotFoundException {
+        super(file);
+        this.file = file;
+    }
+
+    /**
+     * @return File written by this output stream.
+     */
+    File getFile() {
+        return file;
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/FileBufferTest.java
@@ -1,0 +1,26 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.upload.receivers.FileBuffer;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+public class FileBufferTest {
+
+    @Test
+    public void shouldBeAbleToReadFileAfterReceiving() throws IOException {
+        FileBuffer fileBuffer = new FileBuffer();
+        final String data = "Upload data";
+        final byte[] dataBytes = data.getBytes(Charset.defaultCharset());
+        try (OutputStream os = fileBuffer.receiveUpload("uploadData", "text")) {
+            os.write(dataBytes);
+        }
+        final String readData = IOUtils
+            .toString(fileBuffer.getInputStream(), Charset.defaultCharset());
+        Assert.assertEquals(data, readData);
+    }
+}

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/MultiFileBufferTest.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/test/java/com/vaadin/flow/component/upload/tests/MultiFileBufferTest.java
@@ -1,0 +1,45 @@
+package com.vaadin.flow.component.upload.tests;
+
+import com.vaadin.flow.component.upload.receivers.MultiFileBuffer;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+public class MultiFileBufferTest {
+
+    @Test
+    public void shouldBeAbleToReadFilesAfterReceiving() throws IOException {
+        MultiFileBuffer fileBuffer = new MultiFileBuffer();
+        TestData[] testData = { new TestData("upload1", "Upload data 1"),
+            new TestData("upload2", "Upload data 2"),
+            new TestData("upload3", "Upload data 3"), };
+        for (TestData data : testData) {
+            final byte[] dataBytes = data.data
+                .getBytes(Charset.defaultCharset());
+            try (OutputStream os = fileBuffer
+                .receiveUpload(data.filename, "text")) {
+                os.write(dataBytes);
+            }
+        }
+        for (TestData data : testData) {
+            final String readData = IOUtils
+                .toString(fileBuffer.getInputStream(data.filename),
+                    Charset.defaultCharset());
+            Assert.assertEquals(data.data, readData);
+        }
+    }
+
+    class TestData {
+        private final String filename;
+        private final String data;
+
+        public TestData(String filename, String data) {
+            this.filename = filename;
+            this.data = data;
+        }
+    }
+}


### PR DESCRIPTION
* Fix: FileBuffer getInputStream is closed
Note: This version does not create new public APIs