### PR TITLE
feat: Add column in GridContextMenu#dynamicContentHandler

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1938,7 +1938,7 @@ public class GridDemo extends DemoView {
         grid.addColumn(Task::getName).setHeader("Task Name");
         grid.addColumn(Task::getDueDate).setHeader("Due Date");
         GridContextMenu<Task> contextMenu = new GridContextMenu<>(grid);
-        contextMenu.setDynamicContentHandler(task -> {
+        contextMenu.setDynamicContentHandler((task, column) -> {
             if (task == null) {
                 // do not show the context menu when a row is not clicked
                 return false;
@@ -1946,6 +1946,7 @@ public class GridDemo extends DemoView {
             contextMenu.removeAll();
             contextMenu.addItem("Name: " + task.getName());
             contextMenu.addItem("Due date: " + task.getDueDate());
+            contextMenu.addItem("Column: " + (column != null ? column.getKey() : "no column"));
             return true; // show the context menu
         });
         // end-source-example

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/contextmenu/DynamicContextMenuGridPage.java
@@ -39,7 +39,7 @@ public class DynamicContextMenuGridPage extends Div {
 
         GridContextMenu<Person> contextMenu = grid.addContextMenu();
 
-        contextMenu.setDynamicContentHandler(person -> {
+        contextMenu.setDynamicContentHandler((person, column) -> {
             if (person == null || person.getAge() < 30) {
                 // do not open the context menu
                 return false;
@@ -47,6 +47,7 @@ public class DynamicContextMenuGridPage extends Div {
 
             contextMenu.removeAll();
             contextMenu.addItem(person.getFirstName());
+            contextMenu.addItem(column != null ? column.getKey() : "-no column-");
             return true;
         });
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenu.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.contextmenu.ContextMenuBase;
 import com.vaadin.flow.component.contextmenu.MenuManager;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.function.SerializableBiFunction;
+import com.vaadin.flow.function.SerializableBiPredicate;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.shared.Registration;
@@ -41,7 +42,7 @@ public class GridContextMenu<T> extends
         ContextMenuBase<GridContextMenu<T>, GridMenuItem<T>, GridSubMenu<T>>
         implements HasGridMenuItems<T> {
 
-    private SerializablePredicate<T> dynamicContentHandler;
+    private SerializableBiPredicate<T, Grid.Column<T>> dynamicContentHandler;
 
     /**
      * Event that is fired when a {@link GridMenuItem} is clicked inside a
@@ -223,7 +224,7 @@ public class GridContextMenu<T> extends
      * @return the callback function that is executed before opening the context
      *         menu, or {@code null} if not specified.
      */
-    public SerializablePredicate<T> getDynamicContentHandler() {
+    public SerializableBiPredicate<T, Grid.Column<T>> getDynamicContentHandler() {
         return dynamicContentHandler;
     }
 
@@ -247,6 +248,29 @@ public class GridContextMenu<T> extends
      */
     public void setDynamicContentHandler(
             SerializablePredicate<T> dynamicContentHandler) {
+        setDynamicContentHandler((item, column) -> dynamicContentHandler.test(item));
+    }
+
+    /**
+     * Sets a callback that is executed before the context menu is opened.
+     *
+     * <p>
+     * This callback receives the clicked item (if any) and column (if any) as an input parameter
+     * and further can dynamically modify the contents of the context menu. This
+     * is useful in situations where the context menu items cannot be known in
+     * advance and depend on the specific context (i.e. clicked row or column) and thus
+     * can be configured dynamically.
+     *
+     * The boolean return value of this callback specifies if the context menu
+     * will be opened.
+     * </p>
+     *
+     * @param dynamicContentHandler
+     *            the callback function that will be executed before opening the
+     *            context menu.
+     */
+    public void setDynamicContentHandler(
+            SerializableBiPredicate<T, Grid.Column<T>> dynamicContentHandler) {
         this.dynamicContentHandler = dynamicContentHandler;
     }
 
@@ -257,10 +281,12 @@ public class GridContextMenu<T> extends
     protected boolean onBeforeOpenMenu(JsonObject eventDetail) {
         Grid<T> grid = (Grid<T>) getTarget();
         String key = eventDetail.getString("key");
+        String columnId = eventDetail.getString("columnId");
 
         if (getDynamicContentHandler() != null) {
             final T item = grid.getDataCommunicator().getKeyMapper().get(key);
-            return getDynamicContentHandler().test(item);
+            final Grid.Column<T> column = grid.getColumnByKey(columnId);
+            return getDynamicContentHandler().test(item, column);
         }
 
             return super.onBeforeOpenMenu(eventDetail);

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -942,7 +942,8 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
       grid.getContextMenuBeforeOpenDetail = tryCatchWrapper(function(event) {
         const eventContext = grid.getEventContext(event);
         return {
-          key: (eventContext.item && eventContext.item.key) || ""
+          key: (eventContext.item && eventContext.item.key) || "",
+          columnId: (eventContext.column && eventContext.column.id) || ""
         };
       });
 


### PR DESCRIPTION
This PR adds the possibility to dynamically create the context menu based on the clicked column.

For this, the dynamicContentHandler has been changed to a `SerializableBiPredicate<T, Column<T>>` but I kept the `setDynamicContentHandler(SerializablePredicate<T>)` to not break existing apps. Only the corresponding getter (`getDynamicContentHandler`) returns the `SerializableBiPrediacte<T, Column<T>>` now.
In the demo, the `Column` is always `null`, as none of the `Column`s have an ID. So the behavior is the same as in the `GridContextMenuOpenedEvent`.

Unfortunately, I was not able to run the integration tests but I will create a separate issue for that.