### PR TITLE
test: update grid integration test

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
@@ -76,7 +76,7 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
 
         verifyRows(DEFAULT_DATA_PROVIDER_SIZE);
         // new rows are added to end due to size increase
-        Assert.assertEquals(301, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(299, grid.getLastVisibleRowIndex());
 
         grid.scrollToRow(500);
 
@@ -96,7 +96,7 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
         // size has been increased again by default size
         doScroll(1000, 1200, 6, 950, 1100);
 
-        Assert.assertEquals(1001, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(999, grid.getLastVisibleRowIndex());
     }
 
     // @Test TODO

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -138,7 +138,7 @@ import elemental.json.JsonValue;
  *
  */
 @Tag("vaadin-grid")
-@NpmPackage(value = "@vaadin/vaadin-grid", version = "5.7.6")
+@NpmPackage(value = "@vaadin/vaadin-grid", version = "5.7.7")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid.js")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid-column.js")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid-sorter.js")
@@ -4158,7 +4158,7 @@ public class Grid<T> extends Component implements HasStyle, HasSize,
      * Updates an in-memory sorting in Grid's data communicator, taking into
      * account an internal sort orders of the Grid and a sort comparator,
      * handled by GridListDataView API.
-     * 
+     *
      * @param componentSorting
      *            Grid's in-memory sort comparator which is handled by
      *            GridListDataView API


### PR DESCRIPTION
Web-component: grid

Details: Initially test was relying on not working `scrollToIndex` when cache is loading. The request to [scroll](https://github.com/vaadin/vaadin-grid/blob/3253c90bdb438980a9c1eb3d557d4cfb8b1663c4/src/vaadin-grid-scroller.js#L124) to the first visible (adjusted) index on `_effectiveSizeChanged` when [switching to defined size](https://github.com/vaadin/vaadin-flow-components/blob/36981ab480d6e41cfd770f8768eaad2be048c375/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java#L75) was done, but never properly performed before the [change released](https://github.com/vaadin/vaadin-grid/commit/a34fc19d1810dcdd3608cdc9dc5075e7e9979ce4) in wc 5.7.7 with `__scrollToPendingIndex`