### PR TITLE
test: update Grid's IT after scrolling improvements (#428)

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountUnknownGridIT.java
@@ -76,7 +76,7 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
 
         verifyRows(DEFAULT_DATA_PROVIDER_SIZE);
         // new rows are added to end due to size increase
-        Assert.assertEquals(301, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(299, grid.getLastVisibleRowIndex());
 
         grid.scrollToRow(500);
 
@@ -96,7 +96,7 @@ public class ItemCountUnknownGridIT extends AbstractItemCountGridIT {
         // size has been increased again by default size
         doScroll(1000, 1200, 6, 950, 1100);
 
-        Assert.assertEquals(1001, grid.getLastVisibleRowIndex());
+        Assert.assertEquals(999, grid.getLastVisibleRowIndex());
     }
 
     // @Test TODO

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -136,7 +136,7 @@ import elemental.json.JsonValue;
  *
  */
 @Tag("vaadin-grid")
-@NpmPackage(value = "@vaadin/vaadin-grid", version = "5.7.6")
+@NpmPackage(value = "@vaadin/vaadin-grid", version = "5.7.7")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid.js")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid-column.js")
 @JsModule("@vaadin/vaadin-grid/src/vaadin-grid-sorter.js")


### PR DESCRIPTION
Details: It is a **cherry-pick.** Initially, the Grid's ItemCountUnknownGridIT test was relying on not working `scrollToIndex` when cache is loading. The request to scroll to the first visible (adjusted) index on `_effectiveSizeChanged` was done, but never properly performed before the change released in Grid Web Component 5.7.7 with `__scrollToPendingIndex`.