### PR TITLE
fix: Fix setting value to lazy loading ComboBox

### DIFF
--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -364,7 +364,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @Override
     public void setValue(T value) {
-        if (dataCommunicator == null || dataCommunicator.getItemCount() == 0) {
+        if (dataCommunicator == null || dataCommunicator
+                .getDataProvider() instanceof DataCommunicator.EmptyDataProvider) {
             if (value == null) {
                 return;
             } else {

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,6 +45,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
+import static org.junit.Assert.assertEquals;
 
 public class ComboBoxTest {
 
@@ -305,6 +304,16 @@ public class ComboBoxTest {
                 "Cannot set a value for a ComboBox without items.");
         ComboBox<String> combo = new ComboBox<>();
         combo.setValue("foo");
+    }
+
+    // https://github.com/vaadin/vaadin-flow-components/issues/391
+    @Test
+    public void setValueWithLazyItems_doesntThrow() {
+        final ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems(query -> Stream.of("foo", "bar"));
+        comboBox.setValue("foo");
+
+        Assert.assertEquals("foo", comboBox.getValue());
     }
 
     @Test

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridTest.java
@@ -17,7 +17,9 @@
 package com.vaadin.flow.component.grid;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,6 +51,15 @@ public class GridTest {
         grid.setDataProvider(dataProvider);
 
         grid.getListDataView();
+    }
+
+    @Test
+    public void selectItem_lazyDataSet_selectionWorks() {
+        final Grid<String> grid = new Grid<>();
+        grid.setItems(query -> Stream.of("foo", "bar"));
+        grid.select("foo");
+        Assert.assertEquals(1, grid.getSelectedItems().size());
+        Assert.assertTrue(grid.getSelectedItems().contains("foo"));
     }
 
 }


### PR DESCRIPTION
Things should only throw when no items/callback has been set to the CB.
There is a possibility that the value is set but the backend doesn't have
this item available, but that is an edge case and something that should
not happen and should be possible to prevent by resetting the data and
thus a responsibility of the application developer.

Fixes #391