### PR TITLE
feat: add EditOnClick API to enable edit on single click

### DIFF
--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/src/main/java/com/vaadin/flow/component/gridpro/vaadincom/GridProView.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow-demo/src/main/java/com/vaadin/flow/component/gridpro/vaadincom/GridProView.java
@@ -25,6 +25,7 @@ public class GridProView extends DemoView {
         customEditorType();
         enterNextRow();
         singleCellEdit();
+        editOnClick();
     }
 
     private void basicGridPro() {
@@ -206,6 +207,36 @@ public class GridProView extends DemoView {
         // end-source-example
 
         addCard("Single Cell Edit", grid);
+    }
+
+    private void editOnClick() {
+        // begin-source-example
+        // source-example-heading: Single Cell Edit
+        GridPro<Person> grid = new GridPro<>();
+        grid.setItems(createItems());
+
+        /*
+         * It is possible to discard edit mode when moving to the next cell by using grid pro method setSingleCellEdit.
+         */
+        grid.setEditOnClick(true);
+
+        grid.addEditColumn(Person::getName)
+                .text((item, newValue) ->
+                        item.setName(newValue))
+                .setHeader("Name (editable)");
+
+        grid.addEditColumn(Person::getEmail)
+                .text((item, newValue) ->
+                        item.setEmail(newValue))
+                .setHeader("Email (editable)");
+
+        grid.addEditColumn(Person::isSubscriber)
+                .checkbox((item, newValue) ->
+                        item.setSubscriber(newValue))
+                .setHeader("Subscriber (editable)");
+        // end-source-example
+
+        addCard("Edit on Click", grid);
     }
 
     private static List<Person> createItems() {

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/main/java/com/vaadin/flow/component/gridpro/GridPro.java
@@ -49,7 +49,7 @@ import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
 @Tag("vaadin-grid-pro")
-@NpmPackage(value = "@vaadin/vaadin-grid-pro", version = "2.2.2")
+@NpmPackage(value = "@vaadin/vaadin-grid-pro", version = "2.3.0-alpha1")
 @JsModule("@vaadin/vaadin-grid-pro/src/vaadin-grid-pro.js")
 @JsModule("@vaadin/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.js")
 @JsModule("./gridProConnector.js")
@@ -398,6 +398,31 @@ public class GridPro<E> extends Grid<E> {
     @Synchronize("single-cell-edit-changed")
     public boolean getSingleCellEdit() {
         return getElement().getProperty("singleCellEdit", false);
+    }
+
+    /**
+     * Sets the value of the webcomponent's property editOnClick. Default values is false.
+     * When true, cell edit mode gets activated on a single click instead of the default 
+     * double click.
+     *
+     * @param editOnClick
+     *            when <code>true</code>, cell edit mode gets activated on a single
+ *                click instead of the default double click
+     */
+    public void setEditOnClick(boolean editOnClick) {
+        getElement().setProperty("editOnClick", editOnClick);
+    }
+
+    /**
+     * Gets the value of the webcomponent's property editOnClick. Default values is false.
+     * When true, cell edit mode gets activated on a single click instead of the default 
+     * double click.
+     *
+     * @return editOnClick value
+     */
+    @Synchronize("edit-on-click-changed")
+    public boolean getEditOnClick() {
+        return getElement().getProperty("editOnClick", false);
     }
 
     /**

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/src/test/java/com/vaadin/flow/component/gridpro/GridProTest.java
@@ -63,7 +63,13 @@ public class GridProTest {
     @Test
     public void setSingleCellEdit_getSingleCellEdit() {
         grid.setSingleCellEdit(true);
-        Assert.assertEquals(grid.getSingleCellEdit(), true);
+        Assert.assertTrue(grid.getSingleCellEdit());
+    }
+
+    @Test
+    public void setEditOnClick_getEditOnClick() {
+        grid.setEditOnClick(true);
+        Assert.assertTrue(grid.getEditOnClick());
     }
 
     @Test


### PR DESCRIPTION
Add API to enable edit mode to Grid Pro with a single click on the cell.

Fix https://github.com/vaadin/vaadin-grid-pro/issues/73