### PR TITLE
fix: use the next row for getting crud-edit

### DIFF
--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component.crud.testbench;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
@@ -26,6 +27,7 @@ import com.vaadin.testbench.elementsbase.Element;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * TestBench element for the vaadin-crud element
@@ -81,7 +83,12 @@ public class CrudElement extends TestBenchElement {
         if (isEditOnClick()) {
             this.getGrid().getCell(row, 0).click();
         } else {
-            this.$("vaadin-crud-edit").all().get(row).click();
+            GridTHTDElement editCell = getGrid().getAllColumns().stream()
+                    .map(column -> getGrid().getRow(row).getCell(column))
+                    .filter(cell -> cell.getInnerHTML()
+                            .contains("vaadin-crud-edit"))
+                    .collect(Collectors.toList()).get(0);
+            editCell.$("vaadin-crud-edit").get(0).click();
         }
     }
 

--- a/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
+++ b/vaadin-crud-flow-parent/vaadin-crud-testbench/src/main/java/com/vaadin/flow/component/crud/testbench/CrudElement.java
@@ -20,6 +20,7 @@ package com.vaadin.flow.component.crud.testbench;
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
@@ -83,8 +84,9 @@ public class CrudElement extends TestBenchElement {
         if (isEditOnClick()) {
             this.getGrid().getCell(row, 0).click();
         } else {
+            GridTRElement editedRow = getGrid().getRow(row);
             GridTHTDElement editCell = getGrid().getAllColumns().stream()
-                    .map(column -> getGrid().getRow(row).getCell(column))
+                    .map(column -> editedRow.getCell(column))
                     .filter(cell -> cell.getInnerHTML()
                             .contains("vaadin-crud-edit"))
                     .collect(Collectors.toList()).get(0);


### PR DESCRIPTION
Details: with the `_observer.flush` [update](https://github.com/vaadin/vaadin-flow-components/commit/8b5b88893fdf1954ee4eadf83c262d560a0415e6) to the grid's connector, caption#sizer is stamped before the rows in vaadin-crud. It has the first edit button, so we need to get `row + 1` crud-edit when selecting all of those in the crud.