### PR TITLE
fix: revert ensure first page is loaded; ignore test till fixed

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLinesIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestScrollingOver100kLinesIT.java
@@ -49,7 +49,7 @@ public class GridTestScrollingOver100kLinesIT extends AbstractComponentIT {
         allCellContents.forEach(vgcc -> {
             String slotName = vgcc.getAttribute("slot")
                     .replace("vaadin-grid-cell-content-", "");
-            if (Integer.parseInt(slotName) < 7 || Integer.parseInt(slotName) > 20) {
+            if (Integer.parseInt(slotName) <= 180) {
                 Assert.assertTrue(
                         "A grid cell was expected to have text content but had none.",
                         StringUtils.isNotBlank(vgcc.getText()));

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
@@ -58,6 +59,7 @@ public class SortingIT extends AbstractComponentIT {
     }
 
     @Test
+    @Ignore("Fix reverted for https://github.com/vaadin/vaadin-flow-components/issues/427")
     public void setInitialSortOrderGridHidden_showGrid_dataPresentAndSorted() {
         findElement(By.id("sort-hidden-by-age")).click();
         findElement(By.id("show-hidden-grid")).click();

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -349,11 +349,6 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
         }
       })
 
-      // Need to flush FlattenedNodesObserver in order to update `grid._columnTree`
-      // before `_dataProviderChanged` is called. Otherwise, the first page won't
-      // be correctly loaded because of `_canPopulate` returns incorrect result.
-      grid._observer.flush();
-
       grid.dataProvider = tryCatchWrapper(function(params, callback) {
         if (params.pageSize != grid.pageSize) {
           throw 'Invalid pageSize';


### PR DESCRIPTION
The fix https://github.com/vaadin/vaadin-flow-components/commit/8b5b88893fdf1954ee4eadf83c262d560a0415e6 seems to be causing regressions for untested use-cases:
- https://github.com/vaadin/vaadin-grid/issues/2112
- https://github.com/vaadin/vaadin-grid-pro/issues/155

Reverting the change. The test is ignored till the original issue is fixed. https://github.com/vaadin/vaadin-flow-components/issues/427 will be re-opened.