### PR TITLE
test: Verify no errors after Grid detach and clear items

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridClearAfterDetachAndReattachPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridClearAfterDetachAndReattachPage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid.it;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.bean.PeopleGenerator;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+
+@Route("vaadin-grid/clean-grid-items-after-detach-and-reattach")
+public class GridClearAfterDetachAndReattachPage extends Div {
+
+    public static final String GRID_ID = "person-grid-id";
+    public static final String CLEAR_BUTTON_ID = "clear-button-id";
+
+    public static final int GRID_ROW_COUNT = 150;
+
+    public GridClearAfterDetachAndReattachPage() {
+        Div gridContainer = new Div();
+        gridContainer.setWidthFull();
+        Grid<Person> grid = new Grid<>();
+        grid.addColumn(Person::getFirstName);
+        grid.addColumn(Person::getLastName);
+        grid.addColumn(Person::getAge);
+        final List<Person> persons = new PeopleGenerator()
+                .generatePeople(GRID_ROW_COUNT);
+        grid.setItems(persons);
+        grid.setId(GRID_ID);
+
+        NativeButton clearGrid = new NativeButton("Clear Grid", click -> {
+            // Remove grid from it's container and add it again
+            gridContainer.removeAll();
+            gridContainer.add(grid);
+            // Clear the underlying data
+            grid.setItems(Collections.emptyList());
+        });
+        clearGrid.setId(CLEAR_BUTTON_ID);
+
+        gridContainer.add(grid);
+        add(gridContainer);
+        add(clearGrid);
+    }
+}

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridClearAfterDetachAndReattachIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridClearAfterDetachAndReattachIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
+
+import static com.vaadin.flow.component.grid.it.GridClearAfterDetachAndReattachPage.CLEAR_BUTTON_ID;
+import static com.vaadin.flow.component.grid.it.GridClearAfterDetachAndReattachPage.GRID_ID;
+import static com.vaadin.flow.component.grid.it.GridClearAfterDetachAndReattachPage.GRID_ROW_COUNT;
+
+@TestPath("vaadin-grid/clean-grid-items-after-detach-and-reattach")
+public class GridClearAfterDetachAndReattachIT extends AbstractComponentIT {
+
+    @Test // https://github.com/vaadin/vaadin-grid/issues/1837
+    public void clearGridItemsAfterDetachAndReattach_gridItemsClearedWithNoErrors() {
+        open();
+
+        GridElement gridElement = $(GridElement.class).id(GRID_ID);
+        waitUntil((driver) -> gridElement.getLastVisibleRowIndex() > 0);
+        // Scroll to the end
+        gridElement.scrollToRow(gridElement.getRowCount());
+        waitUntil((driver) -> gridElement.getLastVisibleRowIndex() ==
+            GRID_ROW_COUNT - 1);
+
+        // Check that there are no exceptions/errors in the logs
+        checkLogsForErrors();
+
+        $("button").id(CLEAR_BUTTON_ID).click();
+        waitUntil((driver) -> gridElement.getRowCount() == 0);
+
+        // Check that there are no new exceptions/errors throws after
+        // cleaning the grid
+        checkLogsForErrors();
+    }
+}


### PR DESCRIPTION
Verifies the fix on a Flow side for the case when the component with DataCommunicator is being detached-reattached and then being cleared.

Related-to: https://github.com/vaadin/vaadin-grid/issues/1837