### PR TITLE
Chore: fix the deploy script to filter keywords [skip ci]

### DIFF
--- a/scripts/prepareDeploy.sh
+++ b/scripts/prepareDeploy.sh
@@ -84,7 +84,7 @@ for i in $modules
     ## allow setting modules to build from command line or via env var
     [ -n "$modified" ] || modified=$*
     ## otherwise utilise git history to figure out modified modules
-    [ -n "$modified" ] || modified=`git log $lastTag..HEAD --name-only | egrep '\-flow/|-testbench/|parent/pom.xml' | sed -e 's,-flow-parent.*,,g' | sort -u`
+    [ -n "$modified" ] || modified=`git log $lastTag..HEAD --name-only | egrep '\-flow/|-testbench/|parent/pom.xml' | grep -v 'pull|issue' | sed -e 's,-flow-parent.*,,g' | sort -u`
     modules="$modified"
     echo "Increasing version of the modified modules since last release $lastTag"
     for i in $modules


### PR DESCRIPTION
for a commit like this https://github.com/vaadin/vaadin-flow-components/commit/ba9d55859b06c5d5dc920a6828819c299701bc40, the output of the `modules` contains the ` Related-to: https://github.com/vaadin/vaadin-grid-flow/pull/1014 which corrects Grid JavaDoc` part, which leads to a failure when updating the module versions.