### PR TITLE
feat: add feature classifier for Karaf Grid feature

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -71,7 +71,26 @@
     </dependency>
   </dependencies>
   <build>
-    <plugins/>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <configuration>
+          <enableGeneration>true</enableGeneration>
+          <includeProjectArtifact>true</includeProjectArtifact>
+        </configuration>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>generate-features-file</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>features-generate-descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
   <profiles>
     <profile>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/feature/feature.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/feature/feature.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="vaadin-grid-flow">
+   
+    <feature name="vaadin-grid-flow" description="Vaadin Grid Flow" version="${project.version}">
+        <details>Vaadin Grid Flow feature</details>
+    </feature>
+</features>


### PR DESCRIPTION
Adds Karaf "feature" classifier for grid maven artifact.
The classifier can be used to install OSGi bundles with their dependencies into Karaf container.

Part of vaadin/platform#1826