### PR TITLE
fix: Remove unnecessary depend. for components

### DIFF
--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -27,11 +27,6 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>vaadin-details-flow</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -19,19 +19,17 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-button-flow</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -60,7 +58,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
@@ -18,21 +18,17 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -22,7 +22,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -40,7 +39,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -18,9 +18,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-html-components</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -27,7 +26,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -12,15 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -43,7 +35,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -51,6 +42,11 @@
       <artifactId>flow-data</artifactId>
       <version>${flow.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -12,9 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-data</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -32,7 +30,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -22,7 +22,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -39,7 +38,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -12,21 +12,17 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -20,16 +20,6 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-server</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -52,6 +42,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -21,18 +21,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -12,15 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -32,7 +24,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -22,15 +22,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -42,7 +34,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -18,20 +18,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-html-components</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -49,7 +36,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -12,15 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -43,7 +35,11 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
@@ -12,14 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
+      <artifactId>flow-html-components</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -12,21 +12,19 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-dnd</artifactId>
+      <artifactId>flow-html-components</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-dnd</artifactId>
       <version>${flow.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -30,16 +30,6 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-server</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -61,13 +51,11 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-lumo-theme</artifactId>
-      <version>1.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -18,9 +18,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
@@ -12,21 +12,12 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -19,26 +19,16 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -19,19 +19,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -49,7 +36,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
@@ -17,21 +17,17 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -18,21 +18,17 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
@@ -12,15 +12,17 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
@@ -12,15 +12,12 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -18,15 +18,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -42,13 +34,11 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -24,11 +24,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -18,20 +18,7 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow-server</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components</artifactId>
-      <version>${flow.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
-      <version>${flow.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -49,7 +36,11 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
@@ -12,15 +12,12 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-html-components</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -18,21 +18,17 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -12,13 +12,6 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
       <artifactId>flow-data</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -12,14 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-data</artifactId>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -18,21 +18,17 @@
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
-      <artifactId>flow</artifactId>
-      <version>${flow.version}</version>
-      <type>pom</type>
+      <artifactId>flow-server</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-generic</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-test-util</artifactId>
-      <version>${flow.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Switches to using explicit dependencies instead of flow dependency which
brings in code that the component doesn't even depend on. This was
necessary as flow dependency's role has changed and additional dependencies
have been added to it (lit + polymer template integrations).

Also removes bunch of redundant usage of ${flow.version} for components.

Fixes vaadin/flow#9949