### PR TITLE
Ignore generated directory in IT modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ node_modules
 package*json
 pnpm*
 error-screenshots
+
+*/*/frontend/generated


### PR DESCRIPTION
When running the IT modules, this file `frontend/generated/vaadin.ts` appears, polluting the git status.