### PR TITLE
Add MessageList items API

### DIFF
--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/pom.xml
@@ -53,6 +53,10 @@
             <version>${flow.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-lumo-theme</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.12</version>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/main/java/com/vaadin/flow/component/messages/tests/MessageListPage.java
@@ -15,14 +15,46 @@
  */
 package com.vaadin.flow.component.messages.tests;
 
+import java.time.Instant;
+
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.messages.MessageList;
+import com.vaadin.flow.component.messages.MessageListItem;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.Command;
 
 @Route("vaadin-messages/message-list-test")
 public class MessageListPage extends Div {
 
     public MessageListPage() {
-        add(new MessageList());
+
+        MessageListItem foo = new MessageListItem("foo",
+                Instant.parse("2021-01-01T00:00:00.00Z"), "sender",
+                "/test.jpg");
+        foo.setUserAbbreviation("AB");
+        foo.setUserColorIndex(1);
+
+        MessageListItem bar = new MessageListItem("bar");
+
+        MessageList messageList = new MessageList(foo, bar);
+        add(messageList);
+
+        addButton("setText", () -> foo.setText("foo2"));
+        addButton("setTime",
+                () -> foo.setTime(Instant.parse("2000-02-02T02:02:02.00Z")));
+        addButton("setUserName", () -> foo.setUserName("sender2"));
+        addButton("setUserImage", () -> foo.setUserImage("/test2.jpg"));
+        addButton("setAbbreviation", () -> foo.setUserAbbreviation("CD"));
+        addButton("setUserColorIndex", () -> foo.setUserColorIndex(2));
+
+        addButton("setItems", () -> messageList
+                .setItems(new MessageListItem(null, null, "sender3")));
+    }
+
+    private void addButton(String id, Command action) {
+        NativeButton button = new NativeButton(id, e -> action.execute());
+        button.setId(id);
+        add(button);
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow-integration-tests/src/test/java/com/vaadin/flow/component/messages/tests/MessageListIT.java
@@ -15,10 +15,13 @@
  */
 package com.vaadin.flow.component.messages.tests;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.messages.testbench.MessageElement;
 import com.vaadin.flow.component.messages.testbench.MessageListElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.tests.AbstractComponentIT;
@@ -26,13 +29,82 @@ import com.vaadin.tests.AbstractComponentIT;
 @TestPath("vaadin-messages/message-list-test")
 public class MessageListIT extends AbstractComponentIT {
 
+    private MessageListElement messageList;
+
     @Before
     public void init() {
         open();
+        messageList = $(MessageListElement.class).first();
     }
 
     @Test
-    public void test() {
-        Assert.assertTrue($(MessageListElement.class).exists());
+    public void setInitialItems_messagesRendered() {
+        List<MessageElement> messages = messageList.getMessageElements();
+        Assert.assertEquals("Unexpected items count", 2, messages.size());
+
+        MessageElement msg = messages.get(0);
+        Assert.assertEquals("Unexpected text content", "foo", msg.getText());
+        Assert.assertEquals("Unexpected time prop", "2021-01-01T00:00:00Z",
+                msg.getTime());
+        Assert.assertEquals("Unexpected userName prop", "sender",
+                msg.getUserName());
+        Assert.assertEquals("Unexpected userImage prop", "/test.jpg",
+                msg.getUserImg());
+        Assert.assertEquals("Unexpected userAbbreviation prop", "AB",
+                msg.getUserAbbr());
+        Assert.assertEquals("Unexpected userColorIndex prop", 1,
+                msg.getUserColorIndex());
+
+        Assert.assertEquals("Unexpected text content", "bar",
+                messages.get(1).getText());
     }
+
+    @Test
+    public void updateItemPropertiesAfterRendering_messagesUpdated() {
+        MessageElement msg = messageList.getMessageElements().get(0);
+
+        /*
+         * Testing each setter separately to make sure that they all trigger the
+         * client-side property update.
+         */
+
+        clickElementWithJs("setText");
+        Assert.assertEquals("Unexpected text content", "foo2", msg.getText());
+
+        clickElementWithJs("setTime");
+        Assert.assertEquals("Unexpected time prop", "2000-02-02T02:02:02Z",
+                msg.getTime());
+
+        clickElementWithJs("setUserName");
+        Assert.assertEquals("Unexpected userName prop", "sender2",
+                msg.getUserName());
+
+        clickElementWithJs("setUserImage");
+        Assert.assertEquals("Unexpected userImage prop", "/test2.jpg",
+                msg.getUserImg());
+
+        clickElementWithJs("setAbbreviation");
+        Assert.assertEquals("Unexpected userAbbreviation prop", "CD",
+                msg.getUserAbbr());
+
+        clickElementWithJs("setUserColorIndex");
+        Assert.assertEquals("Unexpected userColorIndex prop", 2,
+                msg.getUserColorIndex());
+    }
+
+    @Test
+    public void changeItemsAfterRendering_messagesUpdated() {
+        clickElementWithJs("setItems");
+
+        List<MessageElement> messages = messageList.getMessageElements();
+        Assert.assertEquals("Unexpected items count", 1, messages.size());
+
+        MessageElement msg = messages.get(0);
+
+        Assert.assertEquals("Unexpected text content", "", msg.getText());
+        Assert.assertEquals("Unexpected time prop", null, msg.getTime());
+        Assert.assertEquals("Unexpected userName prop", "sender3",
+                msg.getUserName());
+    }
+
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
@@ -12,27 +12,114 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
  */
 package com.vaadin.flow.component.messages;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.internal.JsonUtils;
+
+import elemental.json.JsonArray;
 
 /**
- * Server-side component for the {@code vaadin-message-list} element.
+ * Server-side component for the {@code vaadin-message-list} element. The
+ * component displays a list of messages that can be configured with
+ * {@link #setItems(Collection)}.
  *
  * @author Vaadin Ltd.
  */
 @Tag("vaadin-message-list")
-// @JsModule("@vaadin/vaadin-messages/src/vaadin-message-list.js")
-// @NpmPackage(value = "@vaadin/vaadin-messages", version = "1.0.0")
+@JsModule("@vaadin/vaadin-messages/src/vaadin-message-list.js")
+@NpmPackage(value = "@vaadin/vaadin-messages", version = "1.0.0-alpha1")
 public class MessageList extends Component implements HasStyle, HasSize {
 
+    private List<MessageListItem> items = Collections.emptyList();
+    private boolean pendingUpdate = false;
+
+    /**
+     * Creates a new message list component. To populate the content of the
+     * list, use {@link #setItems(Collection)}.
+     */
     public MessageList() {
-        getElement().appendChild(new Text("This is MessageList").getElement());
+    }
+
+    /**
+     * Creates a new message list component, with the provided items rendered as
+     * messages.
+     *
+     * @param items
+     *            the items to render as messages
+     * @see #setItems(Collection)
+     */
+    public MessageList(Collection<MessageListItem> items) {
+        setItems(items);
+    }
+
+    /**
+     * Creates a new message list component, with the provided items rendered as
+     * messages.
+     *
+     * @param items
+     *            the items to render as messages
+     * @see #setItems(MessageListItem...)
+     */
+    public MessageList(MessageListItem... items) {
+        setItems(items);
+    }
+
+    /**
+     * Sets the items that will be rendered as messages in this message list.
+     *
+     * @param items
+     *            the items to set
+     */
+    public void setItems(Collection<MessageListItem> items) {
+        this.items.forEach(item -> item.setHost(null));
+
+        this.items = new ArrayList<>(items);
+        items.forEach(item -> item.setHost(this));
+        scheduleItemsUpdate();
+    }
+
+    /**
+     * Sets the items that will be rendered as messages in this message list.
+     *
+     * @param items
+     *            the items to set
+     */
+    public void setItems(MessageListItem... items) {
+        setItems(Arrays.asList(items));
+    }
+
+    /**
+     * Gets the items that are rendered as message components in this message
+     * list.
+     *
+     * @return an unmodifiable view of the list of items
+     */
+    public List<MessageListItem> getItems() {
+        return Collections.unmodifiableList(items);
+    }
+
+    void scheduleItemsUpdate() {
+        if (!pendingUpdate) {
+            pendingUpdate = true;
+            getElement().getNode().runWhenAttached(
+                    ui -> ui.beforeClientResponse(this, ctx -> {
+                        JsonArray itemsJson = JsonUtils.listToJson(items);
+                        getElement().setPropertyJson("items", itemsJson);
+                        pendingUpdate = false;
+                    }));
+        }
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageList.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
@@ -81,9 +82,15 @@ public class MessageList extends Component implements HasStyle, HasSize {
      * Sets the items that will be rendered as messages in this message list.
      *
      * @param items
-     *            the items to set
+     *            the items to set, not {@code null} and not containing any
+     *            {@code null} items
      */
     public void setItems(Collection<MessageListItem> items) {
+        Objects.requireNonNull(items,
+                "Can't set null item collection to MessageList.");
+        items.forEach(item -> Objects.requireNonNull(item,
+                "Can't include null items in MessageList."));
+
         this.items.forEach(item -> item.setHost(null));
 
         this.items = new ArrayList<>(items);
@@ -95,7 +102,7 @@ public class MessageList extends Component implements HasStyle, HasSize {
      * Sets the items that will be rendered as messages in this message list.
      *
      * @param items
-     *            the items to set
+     *            the items to set, none of which can be {@code null}
      */
     public void setItems(MessageListItem... items) {
         setItems(Arrays.asList(items));

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/main/java/com/vaadin/flow/component/messages/MessageListItem.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.messages;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+/**
+ * Item to render as a message component inside a {@link MessageList}.
+ *
+ * @author Vaadin Ltd.
+ * @see MessageList#setItems(Collection)
+ */
+public class MessageListItem implements Serializable {
+
+    private MessageList host;
+
+    private String text;
+    private Instant time;
+
+    private String userName;
+    private String userAbbreviation;
+    private String userImage;
+    private Integer userColorIndex;
+
+    /**
+     * Creates an empty message list item. Use the setter methods to configure
+     * what will be displayed in the message.
+     */
+    public MessageListItem() {
+    }
+
+    /**
+     * Creates a message list item with the provided text, which will be
+     * displayed as plain text in the message body.
+     *
+     * @param text
+     *            the text content of the message
+     * @see #setText(String)
+     */
+    public MessageListItem(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Creates a message list item with the provided text content, time and user
+     * name.
+     * <p>
+     * The text will be rendered as plain text in the message body. The time and
+     * user name will also be displayed in the message component. The user name
+     * is also used in the message's avatar.
+     *
+     * @param text
+     *            the text content of the message
+     * @param time
+     *            the time of sending the message
+     * @param userName
+     *            the user name of the message sender
+     * @see #setText(String)
+     * @see #setTime(Instant)
+     * @see #setUserName(String)
+     */
+    public MessageListItem(String text, Instant time, String userName) {
+        this(text);
+        this.time = time;
+        this.userName = userName;
+    }
+
+    /**
+     * Creates a message list item with the provided text content, time and user
+     * name.
+     * <p>
+     * The text will be rendered as plain text in the message body. The time and
+     * user name will also be displayed in the message component. The user image
+     * will be displayed in an avatar in the message.
+     *
+     * @param text
+     *            the text content of the message
+     * @param time
+     *            the time of sending the message
+     * @param userName
+     *            the user name of the message sender
+     * @param userImage
+     *            the URL of the message sender's image
+     * @see #setText(String)
+     * @see #setTime(Instant)
+     * @see #setUserName(String)
+     * @see #setUserImage(String)
+     */
+    public MessageListItem(String text, Instant time, String userName,
+            String userImage) {
+        this(text, time, userName);
+        this.userImage = userImage;
+    }
+
+    /**
+     * Gets the text content of the message.
+     *
+     * @return the message's text content, or {@code null} if none is set
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Sets the text content of the message. It will be rendered as plain text
+     * in the message body.
+     *
+     * @param text
+     *            the message's text content to set, or {@code null} to remove
+     *            the content
+     */
+    public void setText(String text) {
+        this.text = text;
+        propsChanged();
+    }
+
+    /**
+     * Gets the time of sending the message.
+     *
+     * @return the time of the message, or {@code null} if none is set
+     */
+    @JsonSerialize(using = ToStringSerializer.class)
+    public Instant getTime() {
+        return time;
+    }
+
+    /**
+     * Sets the time of sending the message. It will be displayed in the message
+     * component.
+     *
+     * @param time
+     *            the time of the message to set, or {@code null} to remove the
+     *            time
+     */
+    public void setTime(Instant time) {
+        this.time = time;
+        propsChanged();
+    }
+
+    /**
+     * Gets the user name of the message sender.
+     *
+     * @return the message sender's user name, or {@code null} if none is set
+     */
+    public String getUserName() {
+        return userName;
+    }
+
+    /**
+     * Sets the user name of the message sender. It will be displayed in the
+     * message component and used in the message's avatar.
+     * <p>
+     * In the avatar, the user name is presented in a tooltip on hover. It will
+     * be also used to generate an abbreviation that is displayed as the avatar
+     * content, when no {@link #setUserImage(String)} image} or
+     * {@link #setUserAbbreviation(String)} abbreviation} is explicitly defined.
+     *
+     * @param userName
+     *            the message sender's user name, or {@code null} to remove the
+     *            user name
+     */
+    public void setUserName(String userName) {
+        this.userName = userName;
+        propsChanged();
+    }
+
+    /**
+     * Gets the abbreviation of the message sender.
+     *
+     * @return the message sender's abbreviation, or {@code null} if none is set
+     */
+    @JsonProperty("userAbbr")
+    public String getUserAbbreviation() {
+        return userAbbreviation;
+    }
+
+    /**
+     * Sets the abbreviation of the message sender. It will be used in the
+     * message's avatar, when no {@link #setUserImage(String)} image} is
+     * defined.
+     *
+     * @param userAbbreviation
+     *            the message sender's abbreviation, or {@code null} to remove
+     *            the abbreviation
+     */
+    public void setUserAbbreviation(String userAbbreviation) {
+        this.userAbbreviation = userAbbreviation;
+        propsChanged();
+    }
+
+    /**
+     * Gets the URL to the message sender's image.
+     *
+     * @return the URL to the message sender's image, or {@code null} if none is
+     *         set
+     */
+    @JsonProperty("userImg")
+    public String getUserImage() {
+        return userImage;
+    }
+
+    /**
+     * Sets the URL to the message sender's image. The image be displayed in an
+     * avatar in the message component.
+     *
+     * @param userImage
+     *            the URL to the message sender's image, or {@code null} to
+     *            remove the image
+     */
+    public void setUserImage(String userImage) {
+        this.userImage = userImage;
+        propsChanged();
+    }
+
+    /**
+     * Gets the color index of the message sender.
+     *
+     * @return the color index, or {@code null} if none is set
+     */
+    public Integer getUserColorIndex() {
+        return userColorIndex;
+    }
+
+    /**
+     * Sets the color index of the message sender. It's used in the avatar that
+     * is displayed in the message component.
+     * <p>
+     * The color index defines which color will be used for the border of the
+     * avatar. Color index N applies CSS variable {@code --vaadin-user-color-N}
+     * to the border.
+     *
+     * @param userColorIndex
+     *            the color index to set, or {@code null} to remove it
+     */
+    public void setUserColorIndex(Integer userColorIndex) {
+        this.userColorIndex = userColorIndex;
+        propsChanged();
+    }
+
+    private void propsChanged() {
+        if (getHost() != null) {
+            getHost().scheduleItemsUpdate();
+        }
+    }
+
+    void setHost(MessageList host) {
+        this.host = host;
+    }
+
+    MessageList getHost() {
+        return host;
+    }
+
+}

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -16,5 +16,44 @@
  */
 package com.vaadin.flow.component.messages.tests;
 
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.messages.MessageList;
+import com.vaadin.flow.component.messages.MessageListItem;
+
 public class MessageListTest {
+
+    private MessageList messageList;
+    private MessageListItem item1;
+    private MessageListItem item2;
+
+    @Before
+    public void setup() {
+        messageList = new MessageList();
+        item1 = new MessageListItem();
+        item2 = new MessageListItem();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getItems_returnsUnmodifiableList() {
+        messageList.getItems().add(new MessageListItem());
+    }
+
+    @Test
+    public void setItemsCollection_getItems() {
+        messageList.setItems(Arrays.asList(item1, item2));
+        Assert.assertEquals(Arrays.asList(item1, item2),
+                messageList.getItems());
+    }
+
+    @Test
+    public void setItemsVarArgs_getItems() {
+        messageList.setItems(item1, item2);
+        Assert.assertEquals(Arrays.asList(item1, item2),
+                messageList.getItems());
+    }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/src/test/java/com/vaadin/flow/component/messages/tests/MessageListTest.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.component.messages.tests;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,5 +56,15 @@ public class MessageListTest {
         messageList.setItems(item1, item2);
         Assert.assertEquals(Arrays.asList(item1, item2),
                 messageList.getItems());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setItems_nullCollection_throws() {
+        messageList.setItems((Collection<MessageListItem>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setItems_containsNullItem_throws() {
+        messageList.setItems(item1, null, item2);
     }
 }

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageElement.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.messages.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;vaadin-message&gt;</code>
+ * element.
+ *
+ * @author Vaadin Ltd.
+ */
+@Element("vaadin-message")
+public class MessageElement extends TestBenchElement {
+
+    /**
+     * Gets the text content of the message body.
+     *
+     * @return the text content of the message body
+     */
+    @Override
+    public String getText() {
+        return this.getPropertyString("textContent");
+    }
+
+    /**
+     * Gets the {@code time} property of this element.
+     *
+     * @return the {@code time} property
+     */
+    public String getTime() {
+        return getPropertyString("time");
+    }
+
+    /**
+     * Gets the {@code userName} property of this element.
+     *
+     * @return the {@code userName} property
+     */
+    public String getUserName() {
+        return getPropertyString("userName");
+    }
+
+    /**
+     * Gets the {@code userAbbr} property of this element.
+     *
+     * @return the {@code userAbbr} property
+     */
+    public String getUserAbbr() {
+        return getPropertyString("userAbbr");
+    }
+
+    /**
+     * Gets the {@code userImg} property of this element.
+     *
+     * @return the {@code userImg} property
+     */
+    public String getUserImg() {
+        return getPropertyString("userImg");
+    }
+
+    /**
+     * Gets the {@code userColorIndex} property of this element.
+     *
+     * @return the {@code userColorIndex} property
+     */
+    public int getUserColorIndex() {
+        return getPropertyInteger("userColorIndex");
+    }
+
+}

--- a/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageListElement.java
+++ b/vaadin-messages-flow-parent/vaadin-messages-testbench/src/main/java/com/vaadin/flow/component/messages/testbench/MessageListElement.java
@@ -15,14 +15,28 @@
  */
 package com.vaadin.flow.component.messages.testbench;
 
+import java.util.List;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-message-list&gt;</code>
  * element.
+ *
+ * @author Vaadin Ltd.
  */
 @Element("vaadin-message-list")
 public class MessageListElement extends TestBenchElement {
+
+    /**
+     * Gets the <code>&lt;vaadin-message&gt;</code> elements rendered in this
+     * message list.
+     *
+     * @return
+     */
+    public List<MessageElement> getMessageElements() {
+        return $(MessageElement.class).all();
+    }
 
 }


### PR DESCRIPTION
Resolves https://github.com/vaadin/vaadin-messages/issues/10

Also adds TestBench APIs needed in ITs.

The testing is mostly done in integration tests, because of
the beforeClientResponse optimization that makes it hard to
test with unit tests (copied from AvatarGroup).