### PR TITLE
test: lazy loading Grid shows items properly after filter apply

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -3,9 +3,11 @@ package com.vaadin.flow.component.grid.it;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.grid.Grid;
@@ -14,12 +16,16 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 
 @Route("vaadin-grid/grid-filtering")
 public class GridFilteringPage extends Div {
 
     private static final Set<String> DATA = getData();
+
+    static final String LAZY_FILTERABLE_GRID_ID = "lazy-filterable-grid-id";
+    static final String GRID_FILTER_ID = "grid-filter-id";
 
     public GridFilteringPage() {
         Grid<String> grid = new Grid<>();
@@ -42,6 +48,33 @@ public class GridFilteringPage extends Div {
                 event -> filteredDataProvider.setFilter(field.getValue()));
 
         add(field, grid);
+
+        createLazyLoadingAndFilterableGrid();
+    }
+
+    private void createLazyLoadingAndFilterableGrid() {
+        Grid<String> grid = new Grid<>();
+        grid.addColumn(ValueProvider.identity()).setHeader("Items");
+
+        final List<String> items = IntStream.range(0, 1000)
+                .mapToObj(item -> "Item " + item).collect(Collectors.toList());
+
+        TextField filterField = new TextField("Search Item");
+        filterField.setId(GRID_FILTER_ID);
+        filterField.addValueChangeListener(
+                event -> grid.getGenericDataView().refreshAll());
+
+        grid.setItems(query -> {
+            String searchTerm = filterField.getValue();
+            return items.stream().filter(
+                    item -> searchTerm.isEmpty() || item.contains(searchTerm))
+                    .skip(Math.min(items.size(), query.getOffset()))
+                    .limit(query.getLimit());
+        });
+
+        grid.setId(LAZY_FILTERABLE_GRID_ID);
+
+        add(filterField, grid);
     }
 
     private Collection<String> findAnyMatching(Optional<String> filter) {


### PR DESCRIPTION
Adds a regression test to verify the case when the items are bound to Grid lazily with unknown items count and the filter is being applied to items in the middle of scrolling.

Related-to: https://github.com/vaadin/flow/issues/9988