### PR TITLE
Testbench: On GridElement, use _itemEquals to compare with the activeItem instead of ==

### DIFF
--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridPage.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridPage.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.grid.it;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "vaadin-grid/beangridpage")
@@ -25,7 +26,12 @@ public class BeanGridPage extends Div {
 
     public BeanGridPage() {
         Grid<Person> grid = new Grid<>(Person.class);
-        grid.setItems(new Person("Jorma", 2018));
+        grid.setItems(new Person("Jorma", 2018),
+            new Person("Jarvi", 33));
+        grid.setItemDetailsRenderer(
+            TemplateRenderer.<Person>of("<div>[[item.name]] [[item.age]]</div>")
+                .withProperty("name", Person::getFirstName)
+                .withProperty("age", Person::getAge));
         add(grid);
     }
 

--- a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/BeanGridIT.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/BeanGridIT.java
@@ -15,12 +15,11 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.tests.AbstractComponentIT;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.tests.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("vaadin-grid/beangridpage")
 public class BeanGridIT extends AbstractComponentIT {
@@ -33,4 +32,28 @@ public class BeanGridIT extends AbstractComponentIT {
         Assert.assertFalse("Null values should be presented as empty strings", text.contains("null"));
     }
 
+    @Test
+    public void rowCanBeDeselectedOnSingleSelectMode() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        // Select first row.
+        assertRowSelectionStatus(grid,0,false);
+        grid.select(0);
+        assertRowSelectionStatus(grid,0,true);
+
+        // Try to deselect the wrong row
+        grid.deselect(1);
+        assertRowSelectionStatus(grid,0,true);
+
+        // Deselect the first row
+        grid.deselect(0);
+        assertRowSelectionStatus(grid,0,false);
+    }
+
+    private void assertRowSelectionStatus(GridElement grid, int rowIndex,
+        boolean expectedStatus) {
+        Assert.assertEquals("Unexpected selection status for row " + rowIndex,
+            expectedStatus, grid.getRow(rowIndex).isSelected());
+    }
 }

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.flow.component.grid.testbench;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-grid&gt;</code> element.
@@ -280,7 +279,7 @@ public class GridElement extends TestBenchElement {
     /**
      * Finds the vaadin-grid-cell-content element for the given row and column
      * in header.
-     * 
+     *
      * @param rowIndex
      *            the index of the row in the header
      * @param columnIndex
@@ -371,7 +370,7 @@ public class GridElement extends TestBenchElement {
     /**
      * Deselects the row with the given index.
      *
-     * @param rowIndex
+     * @param row
      *            the row to deselect
      */
     void deselect(GridTRElement row) {
@@ -388,7 +387,10 @@ public class GridElement extends TestBenchElement {
     }
 
     private void removeActiveItem(GridTRElement row) {
-        executeScript("if(arguments[0].activeItem == arguments[1]._item) { arguments[0].activeItem=null;}", this, row);
+        final String JS_DEACTIVATE_IF_ACTIVE =
+            "if(arguments[0]._itemsEqual(arguments[0].activeItem, "
+                + "arguments[1]._item)) { arguments[0].activeItem=null;}";
+        executeScript(JS_DEACTIVATE_IF_ACTIVE, this, row);
     }
 
     /**

--- a/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -15,15 +15,16 @@
  */
 package com.vaadin.flow.component.grid.testbench;
 
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-grid&gt;</code> element.
@@ -279,7 +280,7 @@ public class GridElement extends TestBenchElement {
     /**
      * Finds the vaadin-grid-cell-content element for the given row and column
      * in header.
-     *
+     * 
      * @param rowIndex
      *            the index of the row in the header
      * @param columnIndex


### PR DESCRIPTION
`grid.activeItem==tr._item` evaluates to `false` even when they refer to the same item if the grid that has an itemDetailsRenderer.