### PR TITLE
chore:fix version setting brings in wrong snapshot [skip-ci]

### DIFF
--- a/scripts/prepareDeploy.sh
+++ b/scripts/prepareDeploy.sh
@@ -13,7 +13,7 @@ getLatest() {
 
    stable=`echo "$releases" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | tail -1`
    [ -n "$stable" ] && echo $stable && return
-   pre=`echo "$prereleases" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | egrep 'alpha|beta|rc' | tail -1`
+   pre=`echo "$prereleases" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | grep "^$base" | grep -v "SNAPSHOT" | egrep 'alpha|beta|rc' | tail -1`
    [ -z "$pre" ] && pre=`echo "$prereleases" | grep '<version>' | cut -d '>' -f2 |cut -d '<' -f1 | egrep 'alpha|beta|rc' | tail -1`
    [ -z "$pre" ] && pre="$2"
    expr "$pre" : ".*SNAPSHOT" >/dev/null && echo "Releases cannot depend on SNAPSHOT: $1 - $pre" && exit 1 || echo $pre


### PR DESCRIPTION
the older version doesn't take this into consideration: 
as the `tail -1` will take the wrong snapshot version.
```
      <version>2.5.0.beta1</version>
      <version>2.5-SNAPSHOT</version>
      <version>2.5.osgi-SNAPSHOT</version>
      <version>2.5.osgi-9186-SNAPSHOT</version>
      <version>2.5.osgi-9269-SNAPSHOT</version>
      <version>2.5.osgi-fixes-SNAPSHOT</version>
      <version>2.5.osgi-httpclient-optional-SNAPSHOT</version>
      <version>2.5.osgi-resource-provider-SNAPSHOT</version>
```