### PR TITLE
chore: exclude transitive dependency of themes from flow demo helpers

### DIFF
--- a/vaadin-flow-components-shared/pom.xml
+++ b/vaadin-flow-components-shared/pom.xml
@@ -24,6 +24,16 @@
       <groupId>com.vaadin</groupId>
       <artifactId>flow-component-demo-helpers</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>vaadin-lumo-theme</artifactId>
+          <groupId>com.vaadin</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>vaadin-material-theme</artifactId>
+          <groupId>com.vaadin</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>    
   </dependencies>
 </project>


### PR DESCRIPTION

This is a temporary solution that should be removed once flow has removed themes