### PR TITLE
chore: remove `@Generated` annotation and `javax.annotation-api` dep

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,7 +47,7 @@ tcLog() {
 # log in TC
 tcStatus() {
   [ "$1" = "0" ] && status=SUCCESS || status=FAILURE
-  [ "$1" = "0" ] && text="$3" || status="$2"
+  [ "$1" = "0" ] && text="$3" || text="$2"
   tcMsg "buildStatus status='$status' text='$text'"
   exit $1
 }

--- a/scripts/templates/pom-flow-pro.xml
+++ b/scripts/templates/pom-flow-pro.xml
@@ -65,22 +65,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-              <jdk>11</jdk>
-            </activation>
-            <properties>
-              <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-          </profile>
     </profiles>
 </project>

--- a/scripts/templates/pom-flow.xml
+++ b/scripts/templates/pom-flow.xml
@@ -63,22 +63,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-              <jdk>11</jdk>
-            </activation>
-            <properties>
-              <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-          </profile>
     </profiles>
 </project>

--- a/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow-parent/vaadin-accordion-flow/pom.xml
@@ -92,22 +92,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow-parent/vaadin-app-layout-flow/pom.xml
@@ -118,22 +118,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
+++ b/vaadin-avatar-flow-parent/vaadin-avatar-flow/pom.xml
@@ -83,22 +83,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
+++ b/vaadin-board-flow-parent/vaadin-board-flow/pom.xml
@@ -93,22 +93,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
+++ b/vaadin-button-flow-parent/vaadin-button-flow/pom.xml
@@ -89,22 +89,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/ButtonVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.button;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-button} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.2-SNAPSHOT",
-        "WebComponent: Vaadin.ButtonElement#2.1.0", "Flow#1.2-SNAPSHOT" })
 public enum ButtonVariant {
     LUMO_SMALL("small"), LUMO_LARGE("large"), LUMO_TERTIARY(
             "tertiary"), LUMO_TERTIARY_INLINE("tertiary-inline"), LUMO_PRIMARY(

--- a/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/vaadin-button-flow-parent/vaadin-button-flow/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.button;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
@@ -105,8 +103,6 @@ import com.vaadin.flow.dom.Element;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.2-SNAPSHOT",
-        "WebComponent: Vaadin.ButtonElement#2.1.0", "Flow#1.2-SNAPSHOT" })
 @Tag("vaadin-button")
 @NpmPackage(value = "@vaadin/vaadin-button", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-button/src/vaadin-button.js")

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/pom.xml
@@ -91,22 +91,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Accessibility.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Accessibility.java
@@ -14,8 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * <p>
  * Options for configuring accessibility for the chart. Requires the <a
@@ -26,7 +24,6 @@ import javax.annotation.Generated;
  * Accessibility</a>.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Accessibility extends AbstractConfigurationObject {
 
 	private Boolean describeSingleSeries;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AxisTitle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/AxisTitle.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * The axis title, showing next to the axis line.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class AxisTitle extends AbstractConfigurationObject {
 
 	private VerticalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Back.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Back.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * Defines the back panel of the frame around 3D charts.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Back extends AbstractConfigurationObject {
 
 	private Color color;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Bottom.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Bottom.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * The bottom of the frame around a 3D chart.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Bottom extends AbstractConfigurationObject {
 
 	private Color color;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Breaks.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Breaks.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import java.util.Date;
 import java.time.Instant;
 import com.vaadin.flow.component.charts.util.Util;
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * An array defining breaks in the axis, the sections defined will be left out
  * and all the points shifted closer to each other.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Breaks extends AbstractConfigurationObject {
 
 	private Number breakSize;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ButtonOptions.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ButtonOptions.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -29,7 +28,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-button-symbol</code> class.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class ButtonOptions extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Buttons.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Buttons.java
@@ -14,15 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Options for the export related buttons, print and export. In addition to the
  * default buttons listed here, custom buttons can be added. See <a
  * href="#navigation.buttonOptions">navigation.buttonOptions</a> for general
  * options.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Buttons extends AbstractConfigurationObject {
 
 	private ContextButton contextButton;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartModel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ChartModel.java
@@ -14,8 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
@@ -23,7 +21,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * Options regarding the chart area and plot area as well as general chart
  * options.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class ChartModel extends AbstractConfigurationObject {
 
 	private Boolean alignTicks;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Condition.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Condition.java
@@ -14,12 +14,9 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Under which conditions the rule applies.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Condition extends AbstractConfigurationObject {
 
 	private String _fn_callback;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ContextButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ContextButton.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.ButtonTheme;
 
 /**
  * Options for the export button.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class ContextButton extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Credits.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * Highchart by default puts a credits label in the lower right corner of the
  * chart. This can be changed using these options.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Credits extends AbstractConfigurationObject {
 
 	private Boolean enabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Crosshair.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Crosshair.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -31,7 +30,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * or <code>.highcharts-xaxis-category</code> classes.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Crosshair extends AbstractConfigurationObject {
 
 	private String className;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/CrosshairLabel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/CrosshairLabel.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-crosshair-label</code> class.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class CrosshairLabel extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataGrouping.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataGrouping.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -32,7 +31,6 @@ import java.util.Arrays;
  * be read from the <a href="#Point.dataGroup">Point.dataGroup</a>.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class DataGrouping extends AbstractConfigurationObject {
 
 	private DateTimeLabelFormats dateTimeLabelFormats;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabels.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
@@ -33,7 +32,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * >see example</a>).
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class DataLabels extends AbstractDataLabels {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabelsFunnel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabelsFunnel.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class DataLabelsFunnel extends AbstractDataLabels {
 
 	private Color backgroundColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabelsRange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/DataLabelsRange.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
@@ -25,7 +24,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * <code>yHigh</code> options to allow the higher and lower data label sets
  * individually.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class DataLabelsRange extends AbstractDataLabels {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Dial.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Dial.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-gauge-series .highcharts-dial</code> rule.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Dial extends AbstractConfigurationObject {
 
 	private Color backgroundColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Exporting.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import java.util.Map;
 
 /**
@@ -22,7 +21,6 @@ import java.util.Map;
  * href="http://www.highcharts.com/docs/export-module/export-module-overview"
  * >the docs</a>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Exporting extends AbstractConfigurationObject {
 
 	private Boolean allowHTML;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Frame.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Frame.java
@@ -14,13 +14,10 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Provides the option to draw a frame around the charts by defining a bottom,
  * front and back panel.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Frame extends AbstractConfigurationObject {
 
 	private Back back;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Global.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Global.java
@@ -14,8 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Global options that don't apply to each chart. These options, like the
  * <code>lang</code> options, must be set using the
@@ -29,7 +27,6 @@ import javax.annotation.Generated;
  * });
  * </pre>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Global extends AbstractConfigurationObject {
 
 	private String VMLRadialGradientURL;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Halo.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Halo.java
@@ -14,8 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * <p>
  * Options for the halo appearing around the hovered point in line-type series
@@ -32,7 +30,6 @@ import javax.annotation.Generated;
  * class, with colors inherited from <code>.highcharts-color-{n}</code>.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Halo extends AbstractConfigurationObject {
 
 	private Attributes attributes;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Handles.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Handles.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -31,7 +30,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-navigator-handle-right</code> classes.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Handles extends AbstractConfigurationObject {
 
 	private Color backgroundColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Hover.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Hover.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * Options for the hovered series
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Hover extends AbstractConfigurationObject {
 
 	private Boolean animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/KeyboardNavigation.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/KeyboardNavigation.java
@@ -14,12 +14,9 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Options for keyboard navigation.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class KeyboardNavigation extends AbstractConfigurationObject {
 
 	private Boolean enabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Label.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Label.java
@@ -14,12 +14,10 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 /**
  * Text labels for the plot bands
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Label extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Labels.java
@@ -14,10 +14,8 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Labels extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Lang.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Lang.java
@@ -14,8 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Language object. The language object is global and it can't be set on each
  * chart initiation. Instead, use <code>Highcharts.setOptions</code> to set it
@@ -30,7 +28,6 @@ import javax.annotation.Generated;
  * });
  * </pre>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Lang extends AbstractConfigurationObject {
 
 	private String contextButtonTitle;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Legend.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Legend.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
@@ -22,7 +21,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * The legend is a box containing a symbol and name for each series item or
  * point item in the chart.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Legend extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/LegendNavigation.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/LegendNavigation.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 
@@ -25,7 +24,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * "http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/legend/navigation-enabled-false/"
  * >increase the chart height in export</a>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class LegendNavigation extends AbstractConfigurationObject {
 
 	private Color activeColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/LegendTitle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/LegendTitle.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * A title to be added on top of the legend.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class LegendTitle extends AbstractConfigurationObject {
 
 	private Style style;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Level.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Level.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * Set options on specific levels. Takes precedence over series options, but not
  * point options.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Level extends AbstractConfigurationObject {
 
 	private Color borderColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Loading.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Loading.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
@@ -26,7 +25,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * not part of this configuration object, but part of the <code>lang</code>
  * object.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Loading extends AbstractConfigurationObject {
 
 	private Number hideDuration;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Marker.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Marker.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -22,7 +21,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * series. For settings on the hover state of the individual point, see <a
  * href="#plotOptions.series.marker.states.hover">marker.states.hover</a>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Marker extends AbstractConfigurationObject {
 
 	private Boolean enabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Navigation.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Navigation.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * A collection of options for buttons and menus appearing in the exporting
  * module.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Navigation extends AbstractConfigurationObject {
 
 	private ButtonOptions buttonOptions;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Navigator.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Navigator.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -22,7 +21,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * the entire data set. It provides tools to zoom in and out on parts of the
  * data as well as panning across the dataset.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Navigator extends AbstractConfigurationObject {
 
 	private Boolean adaptToUpdatedData;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NoData.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/NoData.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * page. The actual text to display is set in the <a
  * href="#lang.noData">lang.noData</a> option.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class NoData extends AbstractConfigurationObject {
 
 	private Position position;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Options3d.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Options3d.java
@@ -14,15 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Options to render charts in 3 dimensions. This feature requires
  * <code>highcharts-3d.js</code>, found in the download package or online at <a
  * href="http://code.highcharts.com/highcharts-3d.js">code.highcharts.com/
  * highcharts-3d.js</a>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Options3d extends AbstractConfigurationObject {
 
 	public static final String AXIS_LABEL_POSITION_AUTO = "auto";

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Pane.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Pane.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -23,7 +22,6 @@ import java.util.Arrays;
  * holds general options for the combined X and Y axes set. Each xAxis or yAxis
  * can reference the pane by index.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Pane extends AbstractConfigurationObject {
 
 	private Integer paneIndex;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Pivot.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Pivot.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-gauge-series .highcharts-pivot</code> rule.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Pivot extends AbstractConfigurationObject {
 
 	private Color backgroundColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotBand.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotBand.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.Date;
 import java.time.Instant;
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.util.Util;
 /**
  * An array of objects defining plot bands on the Y axis.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotBand extends AbstractConfigurationObject {
 
 	private Color borderColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotLine.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotLine.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 /**
  * <p>
@@ -30,7 +29,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>className</code> option.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotLine extends AbstractConfigurationObject {
 
 	private String className;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArea.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import java.time.Instant;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsArea extends AreaOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsArearange.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +25,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * The area range is a cartesian series type with higher and lower Y values
  * along an X axis. Requires <code>highcharts-more.js</code>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsArearange extends AreaOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsAreaspline extends AreaOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +25,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * The area spline range is a cartesian series type with higher and lower Y
  * values along an X axis. Requires <code>highcharts-more.js</code>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsAreasplinerange extends AreaOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBar.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsBar extends ColumnOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBoxplot.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * quartile (Q1), median (Q2), upper quartile (Q3), and largest observation
  * (sample maximum).
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsBoxplot extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsBubble.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * along the X and Y axes mark the X and Y values, and the size of the bubble
  * relates to the Z value. Requires <code>highcharts-more.js</code>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsBubble extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import com.vaadin.flow.component.charts.util.Util;
 /**
  * 
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsCandlestick extends OhlcOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumn.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import java.time.Instant;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsColumn extends ColumnOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumnrange.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsColumnrange.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * horizontal bars, set <a href="#chart.inverted">chart.inverted</a> to
  * <code>true</code>.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsColumnrange extends ColumnOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsErrorbar.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * used on graphs to indicate the error, or uncertainty in a reported
  * measurement.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsErrorbar extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFlags.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
 /**
  * 
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsFlags extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFunnel.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsFunnel.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -24,7 +23,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * project, where the top are the initial stages with the most clients. It
  * requires that the <code>modules/funnel.js</code> file is loaded.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsFunnel extends PyramidOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsGauge.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * General plotting options for the gauge series type. Requires
  * <code>highcharts-more.js</code>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsGauge extends GaugeOptions {
 
 	private Boolean animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsHeatmap.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -30,7 +29,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * controlled by settings on the <a href="#colorAxis">colorAxis</a>.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsHeatmap extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsLine.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsLine extends PointOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import com.vaadin.flow.component.charts.util.Util;
 /**
  * 
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsOhlc extends OhlcOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPie.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -22,7 +21,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * A pie chart is a circular chart divided into sectors, illustrating numerical
  * proportion.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsPie extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPolygon.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * stroke is applied through <code>lineWidth</code> and <code>lineColor</code>
  * options. Requires the <code>highcharts-more.js</code> file.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsPolygon extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPyramid.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsPyramid.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -24,7 +23,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * to each point value. Technically it is the same as a reversed funnel chart
  * without a neck.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsPyramid extends PyramidOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsScatter.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsScatter extends PointOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSeries.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import com.vaadin.flow.component.charts.util.Util;
  * General options for all series types.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsSeries extends AbstractPlotOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -25,7 +24,6 @@ import java.util.Arrays;
  * href="#yAxis.maxColor">maxColor</a> and <a href="#yAxis.stops">stops</a>, to
  * control the color of the gauge itself.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsSolidgauge extends GaugeOptions {
 
 	private Boolean animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsSpline.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.Date;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.util.Util;
 
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsSpline extends PointOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsTreemap.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +25,6 @@ import java.util.Arrays;
  * href="http://api.highcharts.com/highmaps#colorAxis">colorAxis</a> is to be
  * used.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsTreemap extends AbstractPlotOptions {
 
 	private Boolean allowDrillToNode;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/PlotOptionsWaterfall.java
@@ -13,7 +13,6 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import com.vaadin.flow.component.charts.util.Util;
 /**
  * Options for the waterfall series type.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class PlotOptionsWaterfall extends ColumnOptions {
 
 	private Boolean allowPointSelect;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSelector.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/RangeSelector.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.ButtonTheme;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * 1 day, 1 week, 1 month etc. It also provides input boxes where min and max
  * dates can be manually input.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class RangeSelector extends AbstractConfigurationObject {
 
 	private Boolean allButtonsEnabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ResetZoomButton.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ResetZoomButton.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.ButtonTheme;
 
 /**
  * The button that appears after a selection zoom, allowing the user to reset
  * zoom.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class ResetZoomButton extends AbstractConfigurationObject {
 
 	private Position position;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Responsive.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Responsive.java
@@ -14,13 +14,10 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * Allows setting a set of rules to apply for different screen or chart sizes.
  * Each rule specifies additional chart options.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Responsive extends AbstractConfigurationObject {
 
 	private Rules rules;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Rules.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Rules.java
@@ -14,13 +14,10 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * A set of rules for responsive settings. The rules are executed from the top
  * down.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Rules extends AbstractConfigurationObject {
 
 	private Condition condition;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Scrollbar.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -34,7 +33,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * <code>.highcharts-scrollbar-track</code>.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Scrollbar extends AbstractConfigurationObject {
 
 	private Color barBackgroundColor;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Select.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Select.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * The appearance of the point marker when selected. In order to allow a point
  * to be selected, set the <code>series.allowPointSelect</code> option to true.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Select extends AbstractConfigurationObject {
 
 	private Boolean enabled;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesTooltip.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/SeriesTooltip.java
@@ -14,14 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
 /**
  * A configuration object for the tooltip rendering of each single series.
  * Properties are inherited from <a href="#tooltip">tooltip</a>, but only the
  * following properties can be defined on a series level.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class SeriesTooltip extends AbstractConfigurationObject {
 
 	private DateTimeLabelFormats dateTimeLabelFormats;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Side.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Side.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -27,7 +26,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * The side for the frame around a 3D chart.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Side extends AbstractConfigurationObject {
 
 	private Color color;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/StackLabels.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/StackLabels.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
@@ -23,7 +22,6 @@ import com.vaadin.flow.component.charts.model.style.Style;
  * columns. In case of an inverted column chart or a bar chart the label is
  * placed to the right of positive bars and to the left of negative bars.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class StackLabels extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/States.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/States.java
@@ -14,9 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
-
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class States extends AbstractConfigurationObject {
 
 	private Hover hover;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Subtitle.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Subtitle.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * The chart's subtitle
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Subtitle extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Time.java
@@ -13,14 +13,11 @@ package com.vaadin.flow.component.charts.model;
  * #L%
  */
 
-import javax.annotation.Generated;
-
 /**
  * These settings affect how datetime axes are laid out, how tooltips are
  * formatted, how series pointIntervalUnit works and how the Highstock range
  * selector handles time.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Time extends AbstractConfigurationObject {
 
     private Number timezoneOffset;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Title.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Title.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Style;
 
 /**
  * The chart's main title.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Title extends AbstractConfigurationObject {
 
 	private HorizontalAlign align;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Tooltip.java
@@ -14,14 +14,12 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import com.vaadin.flow.component.charts.model.style.Style;
 /**
  * Options for the tooltip that appears when the user hovers over a series or
  * point.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Tooltip extends AbstractConfigurationObject {
 
 	private Boolean animation;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Top.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Top.java
@@ -14,13 +14,11 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
  * The top of the frame around a 3D chart.
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Top extends AbstractConfigurationObject {
 
 	private Color color;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/XAxis.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import java.util.Arrays;
  * access to the axis.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class XAxis extends Axis {
 
 	private Boolean allowDecimals;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/YAxis.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +28,6 @@ import java.util.Arrays;
  * programmatic access to the axis.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class YAxis extends Axis {
 
 	private Boolean allowDecimals;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZAxis.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,6 @@ import java.util.Arrays;
  * access to the axis.
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class ZAxis extends Axis {
 
 	private Boolean allowDecimals;

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZAxis.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/ZAxis.java
@@ -48,9 +48,7 @@ public class ZAxis extends Axis {
 	private Color lineColor;
 	private Number lineWidth;
 	private Number linkedTo;
-	private Number max;
 	private Number maxPadding;
-	private Number min;
 	private Number minPadding;
 	private Number minRange;
 	private Number minTickInterval;
@@ -530,32 +528,6 @@ public class ZAxis extends Axis {
 	}
 
 	/**
-	 * @see #setMax(Number)
-	 */
-	public Number getMax() {
-		return max;
-	}
-
-	/**
-	 * <p>
-	 * The maximum value of the axis. If <code>null</code>, the max value is
-	 * automatically calculated. If the <code>endOnTick</code> option is true,
-	 * the <code>max</code> value might be rounded up.
-	 * </p>
-	 * 
-	 * <p>
-	 * If a <a href="#yAxis.tickAmount">tickAmount</a> is set, the axis may be
-	 * extended beyond the set max in order to reach the given number of ticks.
-	 * The same may happen in a chart with multiple axes, determined by <a
-	 * class="internal" href="#chart">chart.alignTicks</a>, where a
-	 * <code>tickAmount</code> is applied internally.
-	 * </p>
-	 */
-	public void setMax(Number max) {
-		this.max = max;
-	}
-
-	/**
 	 * @see #setMaxPadding(Number)
 	 */
 	public Number getMaxPadding() {
@@ -573,22 +545,6 @@ public class ZAxis extends Axis {
 	 */
 	public void setMaxPadding(Number maxPadding) {
 		this.maxPadding = maxPadding;
-	}
-
-	/**
-	 * @see #setMin(Number)
-	 */
-	public Number getMin() {
-		return min;
-	}
-
-	/**
-	 * The minimum value of the axis. If <code>null</code> the min value is
-	 * automatically calculated. If the <code>startOnTick</code> option is true,
-	 * the <code>min</code> value might be rounded down.
-	 */
-	public void setMin(Number min) {
-		this.min = min;
 	}
 
 	/**

--- a/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zones.java
+++ b/vaadin-charts-flow-parent/vaadin-charts-flow/src/main/java/com/vaadin/flow/component/charts/model/Zones.java
@@ -14,7 +14,6 @@ package com.vaadin.flow.component.charts.model;
  */
 
 
-import javax.annotation.Generated;
 import com.vaadin.flow.component.charts.model.style.Color;
 
 /**
@@ -33,7 +32,6 @@ import com.vaadin.flow.component.charts.model.style.Color;
  * >view live demo</a>).
  * </p>
  */
-@Generated(value = "This class is generated and shouldn't be modified", comments = "Incorrect and missing API should be reported to https://github.com/vaadin/vaadin-charts-flow/issues/new")
 public class Zones extends AbstractConfigurationObject {
 
 	private String className;

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/pom.xml
@@ -112,22 +112,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupVariant.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupVariant.java
@@ -15,14 +15,9 @@
  */
 package com.vaadin.flow.component.checkbox;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-checkbox-group} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.CheckboxGroupElement#2.2.2",
-        "Flow#1.1-SNAPSHOT" })
 public enum CheckboxGroupVariant {
     LUMO_VERTICAL("vertical"), LUMO_HELPER_ABOVE_FIELD(
           "helper-above-field"), MATERIAL_VERTICAL("vertical");

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.checkbox;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.ComponentEvent;
@@ -118,8 +116,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.CheckboxElement#2.2.2", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-checkbox")
 @NpmPackage(value = "@vaadin/vaadin-checkbox", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-checkbox/src/vaadin-checkbox.js")

--- a/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
+++ b/vaadin-checkbox-flow-parent/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.checkbox;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -119,9 +117,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.CheckboxGroupElement#2.2.2",
-        "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-checkbox-group")
 @NpmPackage(value = "@vaadin/vaadin-checkbox", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-checkbox/src/vaadin-checkbox-group.js")

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/pom.xml
@@ -90,22 +90,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -291,8 +289,6 @@ import elemental.json.JsonObject;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.5-SNAPSHOT",
-        "WebComponent: Vaadin.ComboBoxElement#5.0.0", "Flow#1.5-SNAPSHOT" })
 @Tag("vaadin-combo-box")
 @NpmPackage(value = "@vaadin/vaadin-combo-box", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-combo-box/src/vaadin-combo-box.js")

--- a/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/pom.xml
@@ -92,22 +92,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/pom.xml
@@ -89,22 +89,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
+++ b/vaadin-context-menu-flow-parent/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/GeneratedVaadinContextMenu.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.contextmenu;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -138,8 +136,6 @@ import elemental.json.JsonObject;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.ContextMenuElement#4.1.0", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-context-menu")
 @NpmPackage(value = "@vaadin/vaadin-context-menu", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-context-menu/src/vaadin-context-menu.js")

--- a/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow-parent/vaadin-cookie-consent-flow/pom.xml
@@ -91,22 +91,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
+++ b/vaadin-crud-flow-parent/vaadin-crud-flow/pom.xml
@@ -106,22 +106,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
+++ b/vaadin-custom-field-flow-parent/vaadin-custom-field-flow/pom.xml
@@ -88,22 +88,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/pom.xml
@@ -89,22 +89,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/vaadin-date-picker-flow-parent/vaadin-date-picker-flow/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.datepicker;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -254,9 +252,6 @@ import elemental.json.JsonObject;
  * is propagated to the internal themable components listed above.
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#2.0-SNAPSHOT",
-        "WebComponent: Vaadin.DatePickerElement#4.0.0-alpha1",
-        "Flow#2.0-SNAPSHOT" })
 @Tag("vaadin-date-picker")
 @NpmPackage(value = "@vaadin/vaadin-date-picker", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-date-picker/src/vaadin-date-picker.js")

--- a/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
+++ b/vaadin-date-time-picker-flow-parent/vaadin-date-time-picker-flow/pom.xml
@@ -99,22 +99,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
+++ b/vaadin-details-flow-parent/vaadin-details-flow/pom.xml
@@ -90,22 +90,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/pom.xml
@@ -100,22 +100,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow-parent/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.dialog;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -50,8 +48,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.DialogElement#null", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-dialog")
 @NpmPackage(value = "@vaadin/vaadin-dialog", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-dialog/src/vaadin-dialog.js")

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/pom.xml
@@ -82,22 +82,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.formlayout;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
@@ -165,8 +163,6 @@ import com.vaadin.flow.dom.Element;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.FormItemElement#2.1.0", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-form-item")
 @NpmPackage(value = "@vaadin/vaadin-form-layout", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-form-layout/src/vaadin-form-item.js")

--- a/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormLayout.java
+++ b/vaadin-form-layout-flow-parent/vaadin-form-layout-flow/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormLayout.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.formlayout;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
@@ -137,8 +135,6 @@ import elemental.json.JsonObject;
  * </tbody>
  * </table>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.FormLayoutElement#2.1.0", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-form-layout")
 @NpmPackage(value = "@vaadin/vaadin-form-layout", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-form-layout/src/vaadin-form-layout.js")

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/pom.xml
@@ -135,22 +135,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridVariant.java
+++ b/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.grid;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-grid} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.GridElement#5.1.0", "Flow#1.1-SNAPSHOT" })
 public enum GridVariant {
     LUMO_NO_BORDER("no-border"), LUMO_NO_ROW_BORDERS(
             "no-row-borders"), LUMO_COLUMN_BORDERS(

--- a/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
+++ b/vaadin-grid-pro-flow-parent/vaadin-grid-pro-flow/pom.xml
@@ -110,22 +110,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow-parent/vaadin-icons-flow/pom.xml
@@ -83,22 +83,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
+++ b/vaadin-iron-list-flow-parent/vaadin-iron-list-flow/pom.xml
@@ -78,22 +78,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
+++ b/vaadin-list-box-flow-parent/vaadin-list-box-flow/pom.xml
@@ -101,22 +101,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow-parent/vaadin-login-flow/pom.xml
@@ -90,22 +90,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
+++ b/vaadin-lumo-theme-flow-parent/vaadin-lumo-theme-flow/pom.xml
@@ -62,22 +62,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
+++ b/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/pom.xml
@@ -62,22 +62,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
+++ b/vaadin-menu-bar-flow-parent/vaadin-menu-bar-flow/pom.xml
@@ -88,22 +88,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
+++ b/vaadin-messages-flow-parent/vaadin-messages-flow/pom.xml
@@ -78,22 +78,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/pom.xml
@@ -83,22 +83,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/vaadin-notification-flow-parent/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.notification;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -88,8 +86,6 @@ Your work has been saved
  * is propagated to the internal {@code <vaadin-notification-card>}.
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.5-SNAPSHOT",
-        "WebComponent: Vaadin.NotificationElement#1.3.0", "Flow#1.5-SNAPSHOT" })
 @Tag("vaadin-notification")
 @NpmPackage(value = "@vaadin/vaadin-notification", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-notification/src/vaadin-notification.js")

--- a/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
+++ b/vaadin-ordered-layout-flow-parent/vaadin-ordered-layout-flow/pom.xml
@@ -83,22 +83,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/pom.xml
@@ -78,22 +78,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/GeneratedVaadinProgressBar.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.progressbar;
 
-import javax.annotation.Generated;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -99,8 +98,6 @@ import com.vaadin.flow.component.dependency.JsModule;
  * </tbody>
  * </table>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.ProgressBarElement#1.1.0", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-progress-bar")
 @JsModule("@vaadin/vaadin-progress-bar/src/vaadin-progress-bar.js")
 public abstract class GeneratedVaadinProgressBar<R extends GeneratedVaadinProgressBar<R>>

--- a/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
+++ b/vaadin-progress-bar-flow-parent/vaadin-progress-bar-flow/src/main/java/com/vaadin/flow/component/progressbar/ProgressBarVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.progressbar;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-progress-bar} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.ProgressBarElement#1.1.0", "Flow#1.1-SNAPSHOT" })
 public enum ProgressBarVariant {
     LUMO_CONTRAST("contrast"), LUMO_ERROR("error"), LUMO_SUCCESS("success");
 

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/pom.xml
@@ -100,22 +100,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.radiobutton;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -99,8 +97,6 @@ import com.vaadin.flow.shared.Registration;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.RadioButtonElement#1.1.2", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-radio-button")
 @JsModule("@vaadin/vaadin-radio-button/src/vaadin-radio-button.js")
 public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioButton<R>>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.radiobutton;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -115,8 +113,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.RadioGroupElement#1.1.2", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-radio-group")
 @JsModule("@vaadin/vaadin-radio-button/src/vaadin-radio-group.js")
 public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGroup<R, T>, T>

--- a/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioGroupVariant.java
+++ b/vaadin-radio-button-flow-parent/vaadin-radio-button-flow/src/main/java/com/vaadin/flow/component/radiobutton/RadioGroupVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.radiobutton;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-radio-group} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.RadioGroupElement#1.1.2", "Flow#1.1-SNAPSHOT" })
 public enum RadioGroupVariant {
     LUMO_VERTICAL("vertical"), LUMO_HELPER_ABOVE_FIELD(
         "helper-above-field"), MATERIAL_VERTICAL("vertical");

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/pom.xml
@@ -109,22 +109,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
@@ -19,8 +19,6 @@ package com.vaadin.flow.component.richtexteditor;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -188,9 +186,6 @@ import elemental.json.JsonArray;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.2-SNAPSHOT",
-        "WebComponent: Vaadin.RichTextEditorElement#1.0.0-alpha3",
-        "Flow#1.2-SNAPSHOT" })
 @Tag("vaadin-rich-text-editor")
 @NpmPackage(value = "@vaadin/vaadin-rich-text-editor", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js")

--- a/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditorVariant.java
+++ b/vaadin-rich-text-editor-flow-parent/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditorVariant.java
@@ -16,15 +16,10 @@ package com.vaadin.flow.component.richtexteditor;
  * #L%
  */
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-rich-text-editor}
  * component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.2-SNAPSHOT",
-        "WebComponent: Vaadin.RichTextEditorElement#1.0.0-alpha3",
-        "Flow#1.2-SNAPSHOT" })
 public enum RichTextEditorVariant {
     LUMO_NO_BORDER("no-border"), LUMO_COMPACT("compact"), MATERIAL_NO_BORDER(
             "no-border");

--- a/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow-parent/vaadin-select-flow/pom.xml
@@ -102,22 +102,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
+++ b/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/generated/GeneratedVaadinSelect.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.select.generated;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -186,8 +184,6 @@ import com.vaadin.flow.shared.Registration;
  * propagated to the internal themable components listed above.
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.SelectElement#2.0.2", "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-select")
 @NpmPackage(value = "@vaadin/vaadin-select", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-select/src/vaadin-select.js")

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/pom.xml
@@ -78,22 +78,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.splitlayout;
 
-import javax.annotation.Generated;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -188,8 +187,6 @@ import com.vaadin.flow.shared.Registration;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.SplitLayoutElement#4.1.0", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-split-layout")
 @JsModule("@vaadin/vaadin-split-layout/src/vaadin-split-layout.js")
 public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitLayout<R>>

--- a/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayoutVariant.java
+++ b/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayoutVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.splitlayout;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-split-layout} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.SplitLayoutElement#4.1.0", "Flow#1.1-SNAPSHOT" })
 public enum SplitLayoutVariant {
     LUMO_SMALL("small"), LUMO_MINIMAL("minimal");
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/pom.xml
@@ -89,22 +89,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,8 +89,6 @@ Tab 1
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.TabElement#2.1.1", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-tab")
 @JsModule("@vaadin/vaadin-tabs/src/vaadin-tab.js")
 @NpmPackage(value = "@vaadin/vaadin-tabs", version = "20.0.0-alpha1")

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -98,8 +97,6 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.TabsElement#2.1.1", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-tabs")
 @JsModule("@vaadin/vaadin-tabs/src/vaadin-tabs.js")
 @NpmPackage(value = "@vaadin/vaadin-tabs", version = "20.0.0-alpha1")

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-tab} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.TabElement#2.1.1", "Flow#1.1-SNAPSHOT" })
 public enum TabVariant {
     LUMO_ICON_ON_TOP("icon-on-top");
 

--- a/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
+++ b/vaadin-tabs-flow-parent/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/TabsVariant.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-tabs} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.TabsElement#2.1.1", "Flow#1.1-SNAPSHOT" })
 public enum TabsVariant {
     LUMO_ICON_ON_TOP("icon-on-top"), LUMO_CENTERED("centered"), LUMO_SMALL(
             "small"), LUMO_MINIMAL("minimal"), LUMO_HIDE_SCROLL_BUTTONS(

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/pom.xml
@@ -87,22 +87,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -46,9 +44,6 @@ import com.vaadin.flow.function.SerializableFunction;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.EmailFieldElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-email-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-email-field.js")

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -37,9 +35,6 @@ import com.vaadin.flow.function.SerializableFunction;
  * &lt;/vaadin-number-field&gt;
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.NumberFieldElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-number-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-number-field.js")

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -82,9 +80,6 @@ import com.vaadin.flow.function.SerializableFunction;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.PasswordFieldElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-password-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-password-field.js")

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.textfield;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -143,9 +141,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.TextAreaElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-text-area")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-text-area.js")

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.component.textfield;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
@@ -167,9 +165,6 @@ import com.vaadin.flow.shared.Registration;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.TextFieldElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-text-field.js")

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
@@ -15,14 +15,9 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-text-area} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.TextAreaElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 public enum TextAreaVariant {
     LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
           "align-right"), LUMO_HELPER_ABOVE_FIELD(

--- a/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
+++ b/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
@@ -15,14 +15,9 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import javax.annotation.Generated;
-
 /**
  * Set of theme variants applicable for {@code vaadin-text-field} component.
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.3-SNAPSHOT",
-        "WebComponent: Vaadin.TextFieldElement#2.3.0-alpha8",
-        "Flow#1.3-SNAPSHOT" })
 public enum TextFieldVariant {
     LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
             "align-right"), LUMO_HELPER_ABOVE_FIELD(

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/pom.xml
@@ -93,22 +93,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow-parent/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.timepicker;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -125,8 +123,6 @@ import elemental.json.JsonObject;
  * is propagated to the internal themable components listed above.
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#2.0-SNAPSHOT",
-        "WebComponent: Vaadin.TimePickerElement#2.0.0", "Flow#2.0-SNAPSHOT" })
 @Tag("vaadin-time-picker")
 @NpmPackage(value = "@vaadin/vaadin-time-picker", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-time-picker/src/vaadin-time-picker.js")

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/pom.xml
@@ -83,22 +83,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>1.3.2</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
     </profiles>
 </project>

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.upload;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -115,8 +113,6 @@ import elemental.json.JsonObject;
  * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.UploadElement#4.2.1", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-upload")
 @NpmPackage(value = "@vaadin/vaadin-upload", version = "20.0.0-alpha1")
 @JsModule("@vaadin/vaadin-upload/src/vaadin-upload.js")

--- a/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUploadFile.java
+++ b/vaadin-upload-flow-parent/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUploadFile.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.upload;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -141,8 +139,6 @@ import elemental.json.JsonObject;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
-        "WebComponent: Vaadin.UploadFileElement#UNKNOWN", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-upload-file")
 @JsModule("@vaadin/vaadin-upload/src/vaadin-upload-file.js")
 public abstract class GeneratedVaadinUploadFile<R extends GeneratedVaadinUploadFile<R>>


### PR DESCRIPTION
`@Generated` annotation is not needed since
- there are no generators for flow components anymore.
- It also depends on a package not available in modern JDKs
- It has source retention, thus no API changes with this change

Fixes: #742